### PR TITLE
docs: add initial design and architecture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,112 +1,139 @@
-# Video Digest Server 🎥
+# Video Digest Server
 
-[![Rust](https://img.shields.io/badge/language-Rust-orange.svg)](https://www.rust-lang.org/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+Video Digest Server is a planned Rust/Tokio service for concurrent video uploads and FFmpeg transcoding.
 
-A high-performance video ingestion and transcoding server designed to act as a bridge between raw camera footage and the editing suite. This server automatically processes uploaded high-bitrate files into lightweight proxies or professional mezzanine formats, ensuring a smooth non-linear editing (NLE) experience.
+When multiple clients upload the same video with the same profile, the target behavior is to create one canonical transcoding job and return that job ID to duplicate requests.
 
-## 📖 Overview
+> Current status: design documentation only. Implementation will be added in later PRs.
 
-The **Video Digest Server** is built in Rust to leverage memory safety and fearless concurrency. Its primary role is to handle large video uploads from various camera sources, queue them for processing, and encode them based on predefined profiles. 
+## Core Idea
 
-By converting heavy raw files into "proxies," editors can work with low-resolution versions of their footage without straining system resources, later relinking to the original high-resolution files for final render.
+The service deduplicates work by this key:
 
-## ✨ Features
-
-- **Async Processing Pipeline**: Built with `Tokio` to handle multiple simultaneous uploads and encoding jobs.
-- **Dynamic Profile Management**: Switch between "Quick Proxy" and "Professional Mezzanine" formats via configuration.
-- **FFmpeg Integration**: Leverages the power of FFmpeg for industry-standard codec support.
-- **Queue System**: Prevents server saturation by managing transcoding tasks in a priority queue.
-- **Hardware Acceleration**: Supports NVENC/QuickSync (via FFmpeg) for faster encoding.
-
-## 🛠 Build Steps
-
-### Prerequisites
-
-- **Rust**: Install via [rustup](https://rustup.rs/) (`cargo`).
-- **FFmpeg**: Must be installed on the system path with the required codecs enabled.
-  - Linux: `sudo apt install ffmpeg`
-  - macOS: `brew install ffmpeg`
-
-### Installation
-
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/youruser/video-digest-server.git
-   cd video-digest-server
-   ```
-
-2. Configure environment variables:
-   ```bash
-   cp .env.example .env
-   # Edit .env to set upload directories and port settings
-   ```
-
-3. Build the project:
-   ```bash
-   cargo build --release
-   ```
-
-4. Run the server:
-   ```bash
-   cargo run --release
-   ```
-
-## ⚙️ Encoding Profiles
-
-The server allows you to define profiles in `config.toml`. Depending on the project requirements, you can choose between lightweight web-ready proxies or professional intermediate codecs.
-
-### 1. General Proxy (Fast & Lightweight)
-Designed for remote collaboration and low-spec laptops.
-
-| Feature | Value |
-| :--- | :--- |
-| **Codec** | H.264 / AAC |
-| **Container** | `.mp4` or `.mov` |
-| **Resolution** | 1280x720 (720p) |
-| **Bitrate** | 2-5 Mbps |
-
-### 2. Professional Mezzanine (Edit Ready)
-Designed for high-end post-production houses where visual fidelity and scrubbability are more important than file size.
-
-| Format | Codec | Container | Use Case |
-| :--- | :--- | :--- | :--- |
-| **Apple ProRes** | `prores_ks` | `.mov` | Industry standard for macOS/Final Cut / Premiere |
-| **Avid DNxHD** | `dnxhd` | `.mxf` | Optimized for Avid Media Composer |
-| **CineForm** | `cineform` | `.mov` | High-quality intermediate with alpha support |
-| **APV** | `apv` | `.mov` | Specialized high-efficiency professional format |
-
-## 🚀 Examples
-
-### API Upload Example
-You can trigger a digest job by sending a POST request to the server:
-
-```bash
-curl -X POST http://localhost:8080/upload \
-  -F "video=@/path/to/camera_raw_01.R3D" \
-  -F "profile=prores_proxy"
+```text
+DedupKey = (content_sha256, profile_name)
 ```
 
-### Configuration Example (`config.toml`)
-```toml
-[profiles.web_proxy]
-codec = "libx264"
-container = "mp4"
-resolution = "1280x720"
-crf = 23
+The main concurrency issue is a logical check-then-insert race in an in-memory `HashMap`. This is an application-level race condition, not a Rust memory data race.
 
-[profiles.prores_proxy]
-codec = "prores_ks"
-profile = 1 # ProRes Proxy
-container = "mov"
-resolution = "1920x1080"
+## System Overview
 
-[profiles.avid_dnxhd]
-codec = "dnxhd"
-container = "mxf"
-resolution = "1920x1080"
+```mermaid
+flowchart LR
+    C["Concurrent Clients"] -->|"POST /api/jobs"| API["Axum HTTP API"]
+    API --> U["Upload Stream"]
+    U --> H["Temp File + SHA-256"]
+    H --> R["RegistryState<br/>Arc&lt;Mutex&gt;"]
+    R -->|"new canonical job"| Q["Job Queue"]
+    Q --> W["Worker Pool"]
+    W --> F["FFmpeg"]
+    F --> A["Local Artifact"]
 ```
 
-## 📜 License
+The target service is intentionally small: no database, no authentication, no session management, and no required UI. Runtime job state is kept in memory and is lost on restart.
 
-Distributed under the MIT License. See `LICENSE` for more information.
+## Race Condition
+
+Naive check-then-insert can create duplicate jobs:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant A as Request A
+    participant B as Request B
+    participant R as Dedup HashMap
+
+    A->>R: check key
+    R-->>A: missing
+    B->>R: check same key
+    R-->>B: missing
+    A->>A: create job J1
+    B->>B: create job J2
+    A->>R: insert J1
+    B->>R: insert J2
+```
+
+The planned fix is to perform lookup and insertion inside one mutex-protected critical section:
+
+```mermaid
+flowchart TD
+    L["lock registry"] --> E{"dedup.entry(key)"}
+    E -->|"occupied"| O["return existing job_id"]
+    E -->|"vacant"| N["create job_id"]
+    N --> D["insert dedup entry"]
+    D --> J["insert job metadata"]
+    J --> Q["enqueue canonical job"]
+    O --> U["unlock registry"]
+    Q --> U
+```
+
+The mutex protects registry mutation only. Upload streaming, hashing, FFmpeg execution, and artifact download happen outside the lock.
+
+## Request Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant API as API
+    participant R as Registry
+    participant Q as Queue
+    participant W as Worker
+
+    C->>API: POST /api/jobs
+    API->>API: stream file + compute SHA-256
+    API->>R: lock + get_or_create(DedupKey)
+    alt new key
+        R->>Q: enqueue job
+        R-->>API: deduplicated=false
+    else existing key
+        R-->>API: deduplicated=true
+    end
+    API-->>C: job response
+    Q->>W: dequeue job
+    W->>W: run FFmpeg profile
+```
+
+If an upload is interrupted, the hash is not finalized and no job is registered.
+
+## Job States
+
+```mermaid
+stateDiagram-v2
+    [*] --> queued
+    queued --> running
+    running --> succeeded
+    running --> failed
+    succeeded --> [*]
+    failed --> [*]
+```
+
+Invalid transitions are rejected.
+
+## API Surface
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/health` | Health check |
+| `POST` | `/api/jobs` | Upload video and create or reuse a job |
+| `GET` | `/api/jobs` | List recent jobs |
+| `GET` | `/api/jobs/{job_id}` | Read job status |
+| `GET` | `/api/jobs/{job_id}/artifact` | Download succeeded artifact |
+
+## Scope
+
+| In scope | Out of scope |
+|---|---|
+| Rust/Tokio + Axum API | database persistence |
+| multipart uploads | authentication |
+| SHA-256 content hashing | session management |
+| in-memory dedup registry | web dashboard |
+| worker queue | distributed processing |
+| YAML FFmpeg profiles | resumable upload |
+| local filesystem artifacts | runtime profile reload |
+
+## Documentation
+
+- [Architecture](docs/ARCHITECTURE.md)
+- [API specification](docs/API_SPEC.md)
+- [Test plan](docs/TEST_PLAN.md)

--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -1,0 +1,135 @@
+# API Specification
+
+## Base URL
+
+```text
+http://localhost:8080
+```
+
+This document describes the target API contract. Endpoints will be implemented in subsequent PRs.
+
+---
+
+## `GET /api/health`
+
+### Response
+
+```json
+{
+  "status": "ok"
+}
+```
+
+---
+
+## `POST /api/jobs`
+
+Create or deduplicate a transcoding job.
+
+### Request
+
+```text
+Content-Type: multipart/form-data
+```
+
+Fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `file` | file | yes | Uploaded video file |
+| `profile` | string | yes | Profile name defined in YAML |
+
+### Behavior
+
+If `(content_hash, profile)` does not exist:
+
+- create new canonical job
+- enqueue job
+- return `deduplicated=false`
+
+If `(content_hash, profile)` already exists:
+
+- do not create a new job
+- do not enqueue
+- return existing `job_id`
+- return `deduplicated=true`
+
+### Response: New Job
+
+```json
+{
+  "job_id": "uuid",
+  "status": "queued",
+  "deduplicated": false,
+  "profile": "web_720p",
+  "content_hash": "sha256..."
+}
+```
+
+### Response: Deduplicated Job
+
+```json
+{
+  "job_id": "uuid",
+  "status": "queued",
+  "deduplicated": true,
+  "profile": "web_720p",
+  "content_hash": "sha256..."
+}
+```
+
+---
+
+## `GET /api/jobs/{job_id}`
+
+### Response
+
+```json
+{
+  "job_id": "uuid",
+  "status": "succeeded",
+  "profile": "web_720p",
+  "content_hash": "sha256...",
+  "created_at": "2026-04-27T00:00:00Z",
+  "started_at": "2026-04-27T00:00:01Z",
+  "finished_at": "2026-04-27T00:00:03Z",
+  "artifact": {
+    "path": "data/jobs/{job_id}/output/proxy.mp4"
+  },
+  "error": null
+}
+```
+
+---
+
+## `GET /api/jobs`
+
+Returns recent jobs.
+
+Planned response:
+
+```json
+{
+  "jobs": [
+    {
+      "job_id": "uuid",
+      "status": "succeeded",
+      "profile": "web_720p",
+      "content_hash": "sha256..."
+    }
+  ]
+}
+```
+
+---
+
+## `GET /api/jobs/{job_id}/artifact`
+
+Downloads the output artifact.
+
+Rules:
+
+- `succeeded`: return artifact file
+- `queued` / `running`: return not-ready error
+- `failed`: return failure error
+- unknown `job_id`: return 404

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,164 @@
+# Architecture
+
+## Overview
+
+Video Digest Server is a concurrent HTTP ingest server written in Rust.
+
+The target architecture is intentionally small:
+
+```text
+HTTP API -> Upload Stream -> Hash + Temp File -> Dedup Registry -> Job Queue -> Worker -> FFmpeg -> Artifact
+```
+
+The system does not use a database. All runtime state is in memory.
+
+This document describes the target design. The implementation is not yet present in this repository.
+
+---
+
+## Components
+
+### 1. HTTP API
+
+Responsibilities:
+
+- accept multipart uploads
+- validate profile name
+- stream file body
+- return job response
+- expose job status
+- expose artifact download
+
+Expected framework:
+
+- Axum
+- Tokio
+
+### 2. Upload Handler
+
+Responsibilities:
+
+- read multipart file stream
+- write bytes to a temporary file
+- compute SHA-256 while reading the stream
+- finalize hash only after the upload completes
+- pass finalized hash to dedup registry
+
+The upload handler must not insert a job before the upload completes.
+
+### 3. Dedup Registry
+
+Responsibilities:
+
+- maintain mapping from `DedupKey` to `DedupEntry`
+- ensure only one canonical job exists for each `(content_hash, profile_name)`
+- prevent check-then-insert race
+
+Target structure:
+
+```rust
+struct RegistryState {
+    dedup: HashMap<DedupKey, DedupEntry>,
+    jobs: HashMap<JobId, Job>,
+}
+```
+
+Target synchronization:
+
+```rust
+Arc<tokio::sync::Mutex<RegistryState>>
+```
+
+### 4. Job Queue
+
+Responsibilities:
+
+- accept only new canonical jobs
+- provide jobs to workers
+- prevent duplicate processing
+
+The queue should not receive deduplicated requests.
+
+### 5. Worker Pool
+
+Responsibilities:
+
+- receive jobs from queue
+- update status from `queued` to `running`
+- execute FFmpeg command
+- update status to `succeeded` or `failed`
+
+### 6. FFmpeg Runner
+
+Responsibilities:
+
+- read profile arguments from YAML profile config
+- build command using argument array
+- run FFmpeg as an external process
+- record success or failure
+
+The client never sends raw FFmpeg arguments.
+
+### 7. Local Storage
+
+Responsibilities:
+
+- store temporary upload files
+- store canonical job input files
+- store output artifacts
+
+Target layout:
+
+```text
+data/
+  tmp/
+  jobs/
+    {job_id}/
+      input/
+      output/
+```
+
+---
+
+## Shared State
+
+| State | Owner | Synchronization |
+|---|---|---|
+| dedup map | `RegistryState` | Mutex |
+| job map | `RegistryState` | Mutex |
+| job queue | Queue component | async channel / mutex |
+| profiles | loaded at startup | immutable shared reference |
+| local files | filesystem | unique paths by job ID |
+
+---
+
+## Locking Rules
+
+Lock should be held only for small shared-state operations.
+
+Allowed under lock:
+
+- check dedup key
+- insert dedup entry
+- insert job metadata
+- update job status
+- read job metadata
+
+Not allowed under lock:
+
+- reading upload stream
+- hashing large files
+- FFmpeg execution
+- artifact download
+- long polling
+
+---
+
+## Job State Machine
+
+```text
+queued -> running -> succeeded
+queued -> running -> failed
+```
+
+Invalid transitions must be rejected.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,126 @@
+# Test Plan
+
+## Purpose
+
+The tests are designed to prove that the server is safe under concurrent access to shared state.
+
+The primary safety property:
+
+```text
+For the same (content_hash, profile), only one canonical job is created.
+```
+
+This document describes the planned tests. Tests will be implemented along with the server in subsequent PRs.
+
+---
+
+## Test Matrix
+
+| Test | Level | Purpose |
+|---|---|---|
+| `dedup_registry_concurrent_access` | unit/integration | Verify atomic check-and-insert |
+| `same_file_concurrent_upload` | integration | Verify HTTP-level dedup |
+| `same_filename_different_content` | integration | Verify filename is not identity |
+| `worker_no_duplicate_processing` | integration | Verify one job is not processed twice |
+| `invalid_status_transition` | unit | Verify job state machine |
+| `incomplete_upload_no_job` | integration | Verify dropped request does not create job |
+
+---
+
+## 1. `dedup_registry_concurrent_access`
+
+### Setup
+
+- create shared `RegistryState`
+- create one `DedupKey`
+- spawn 100 Tokio tasks
+- every task calls `get_or_create(DedupKey)`
+
+### Expected
+
+- one canonical job
+- all returned job IDs are equal
+- dedup map size is 1
+
+---
+
+## 2. `same_file_concurrent_upload`
+
+### Setup
+
+- start test server
+- prepare one small sample file
+- spawn N HTTP clients
+- every client uploads the same file and same profile
+
+### Expected
+
+- all successful responses contain the same `job_id`
+- `deduplicated=false` appears once
+- `deduplicated=true` appears N-1 times
+- FFmpeg / mock transcoder is invoked once
+
+---
+
+## 3. `same_filename_different_content`
+
+### Setup
+
+- prepare two files with different bytes
+- send both as original filename `sample.mp4`
+
+### Expected
+
+- `content_hash` differs
+- `job_id` differs
+- dedup does not use filename as identity
+
+---
+
+## 4. `worker_no_duplicate_processing`
+
+### Setup
+
+- create multiple jobs
+- run multiple workers
+- track processing count by `job_id`
+
+### Expected
+
+- each job is processed at most once
+- terminal state is `succeeded` or `failed`
+- invalid state transition does not occur
+
+---
+
+## 5. `incomplete_upload_no_job`
+
+### Setup
+
+- open connection
+- begin upload
+- drop connection before completion
+
+### Expected
+
+- no content hash finalized
+- no dedup entry
+- no job metadata
+- no queue enqueue
+
+---
+
+## CI
+
+Minimum required CI command:
+
+```bash
+cargo test --all
+```
+
+Optional:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+```


### PR DESCRIPTION
## Summary

- Defines the target design for a concurrent video ingest server in Rust/Tokio
- Documents the deduplication contract: one canonical transcoding job per `(content_hash, profile)` pair, even under concurrent uploads
- Adds README with mermaid diagrams (system overview, race condition, request flow, job state machine)
- Adds `docs/ARCHITECTURE.md`, `docs/API_SPEC.md`, `docs/TEST_PLAN.md`

## Scope

This PR is documentation-only. No Rust code, no `Cargo.toml`, no CI workflow yet — those land in subsequent PRs once the design is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)