### PR TITLE
docs: refine architecture, API contract, and test plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,28 @@ When multiple clients upload the same video with the same profile, the target be
 
 > Current status: design documentation only. Implementation will be added in later PRs.
 
+## Scope
+
+This project is intentionally scoped as a focused Video Digest Server implementation. The goal is not to build a full video platform, but to implement the backend path needed to demonstrate concurrent access to a shared resource, explain the race condition, fix it, and prove the fix with tests.
+
 ## Core Idea
 
-The service deduplicates work by this key:
+The shared resource is the in-memory job registry:
+
+```text
+RegistryState {
+  dedup: HashMap<DedupKey, DedupEntry>,
+  jobs: HashMap<JobId, Job>,
+}
+```
+
+The deduplication key is:
 
 ```text
 DedupKey = (content_sha256, profile_name)
 ```
 
-The main concurrency issue is a logical check-then-insert race in an in-memory `HashMap`. This is an application-level race condition, not a Rust memory data race.
+The main concurrency issue is a logical check-then-insert race in `dedup`. This is an application-level race condition, not a Rust memory data race.
 
 ## System Overview
 
@@ -24,13 +37,22 @@ flowchart LR
     API --> U["Upload Stream"]
     U --> H["Temp File + SHA-256"]
     H --> R["RegistryState<br/>Arc&lt;Mutex&gt;"]
-    R -->|"new canonical job"| Q["Job Queue"]
+    R -->|"new canonical job_id"| Q["Job Queue"]
     Q --> W["Worker Pool"]
     W --> F["FFmpeg"]
     F --> A["Local Artifact"]
 ```
 
-The target service is intentionally small: no database, no authentication, no session management, and no required UI. Runtime job state is kept in memory and is lost on restart.
+Runtime state is kept in memory and is lost on restart. Uploaded files and output artifacts are stored on the local filesystem.
+
+## Concurrency Goals
+
+| Goal | Project behavior |
+|---|---|
+| Concurrent requests to the same resource | Multiple clients can upload the same bytes with the same profile at the same time |
+| Race condition to analyze | Naive dedup lookup can create duplicate jobs for one `(content_sha256, profile_name)` |
+| Fix | Protect `RegistryState` with `Arc<tokio::sync::Mutex<_>>` and keep lookup plus insert in one critical section |
+| Evidence | Registry concurrency tests, upload integration tests, worker processing tests, and CI quality gates |
 
 ## Race Condition
 
@@ -53,21 +75,23 @@ sequenceDiagram
     B->>R: insert J2
 ```
 
-The planned fix is to perform lookup and insertion inside one mutex-protected critical section:
+The planned fix is to perform lookup and registry mutation inside one mutex-protected critical section:
 
 ```mermaid
 flowchart TD
     L["lock registry"] --> E{"dedup.entry(key)"}
-    E -->|"occupied"| O["return existing job_id"]
+    E -->|"occupied"| O["copy existing job snapshot"]
     E -->|"vacant"| N["create job_id"]
     N --> D["insert dedup entry"]
     D --> J["insert job metadata"]
-    J --> Q["enqueue canonical job"]
     O --> U["unlock registry"]
-    Q --> U
+    J --> U
+    U --> Q{"new job?"}
+    Q -->|"yes"| EN["enqueue job_id outside lock"]
+    Q -->|"no"| R["return existing job"]
 ```
 
-The mutex protects registry mutation only. Upload streaming, hashing, FFmpeg execution, and artifact download happen outside the lock.
+The mutex protects registry mutation only. Upload streaming, hashing, FFmpeg execution, artifact download, queue enqueue, and response serialization happen outside the lock.
 
 ## Request Flow
 
@@ -84,17 +108,28 @@ sequenceDiagram
     API->>API: stream file + compute SHA-256
     API->>R: lock + get_or_create(DedupKey)
     alt new key
-        R->>Q: enqueue job
-        R-->>API: deduplicated=false
+        R-->>API: new job_id
+        API->>Q: enqueue job_id outside lock
+        API-->>C: deduplicated=false, status=queued
     else existing key
-        R-->>API: deduplicated=true
+        R-->>API: existing job snapshot
+        API-->>C: deduplicated=true, current status
     end
-    API-->>C: job response
-    Q->>W: dequeue job
+    Q->>W: deliver job_id to one worker
     W->>W: run FFmpeg profile
 ```
 
 If an upload is interrupted, the hash is not finalized and no job is registered.
+
+## Failure Handling
+
+| Failure | Effect |
+|---|---|
+| Upload connection dropped mid-stream | Hash is not finalized, no dedup entry, no job registered, temp file discarded |
+| Client A drops mid-upload, then client B uploads the same bytes | A leaves no trace; B's upload computes its own hash and becomes the canonical job |
+| FFmpeg exits non-zero | Job transitions `running -> failed`, `error` field stores a summary |
+| Worker crash mid-FFmpeg | Job may remain `running`; automatic recovery is out of scope |
+| Server restart | All in-memory job state is lost; uploaded inputs and finished artifacts on disk are not garbage-collected automatically |
 
 ## Job States
 
@@ -120,17 +155,50 @@ Invalid transitions are rejected.
 | `GET` | `/api/jobs/{job_id}` | Read job status |
 | `GET` | `/api/jobs/{job_id}/artifact` | Download succeeded artifact |
 
-## Scope
+Clients send only a profile name. Raw FFmpeg arguments from clients are not accepted.
 
-| In scope | Out of scope |
-|---|---|
-| Rust/Tokio + Axum API | database persistence |
-| multipart uploads | authentication |
-| SHA-256 content hashing | session management |
-| in-memory dedup registry | web dashboard |
-| worker queue | distributed processing |
-| YAML FFmpeg profiles | resumable upload |
-| local filesystem artifacts | runtime profile reload |
+## In Scope
+
+- Rust/Tokio + Axum API
+- multipart uploads
+- SHA-256 content hashing
+- in-memory dedup registry
+- worker queue
+- YAML FFmpeg profiles
+- local filesystem artifacts
+- focused concurrency and state-machine tests
+
+## Out of Scope
+
+- database persistence, including SQLite and PostgreSQL
+- authentication and session management
+- web dashboard or required UI
+- distributed workers
+- resumable uploads
+- cloud object storage
+- GPU acceleration or advanced codec tuning
+- runtime profile reload
+- production-grade observability and deployment automation
+
+## Quality Gates
+
+Once the Rust scaffold exists, CI should run:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --all
+```
+
+Implementation code should not use `unwrap()` or `expect()` outside tests.
+
+## Benchmark Results
+
+Benchmark numbers are not target KPIs and should not be filled in before implementation. After implementation, measured results can be recorded with this template:
+
+| Scenario | Clients | Profile | Canonical jobs | Dedup hits | FFmpeg spawns | Duplicate jobs | Elapsed |
+|---|---:|---|---:|---:|---:|---:|---:|
+| same file concurrent upload | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
 
 ## Documentation
 

--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -1,18 +1,35 @@
 # API Specification
 
+This document describes the target API contract. Endpoints will be implemented in later PRs.
+
 ## Base URL
 
 ```text
 http://localhost:8080
 ```
 
-This document describes the target API contract. Endpoints will be implemented in subsequent PRs.
+## Profile Rule
 
----
+Clients send only a profile name, for example `web_720p`.
+
+Raw FFmpeg arguments from clients are not accepted. FFmpeg arguments are loaded from server-side YAML profile configuration.
+
+## Error Shape
+
+Error responses use a stable JSON shape:
+
+```json
+{
+  "error": {
+    "code": "unknown_profile",
+    "message": "profile does not exist"
+  }
+}
+```
 
 ## `GET /api/health`
 
-### Response
+Response:
 
 ```json
 {
@@ -20,41 +37,30 @@ This document describes the target API contract. Endpoints will be implemented i
 }
 ```
 
----
-
 ## `POST /api/jobs`
 
 Create or deduplicate a transcoding job.
 
-### Request
+Request:
 
 ```text
 Content-Type: multipart/form-data
 ```
 
-Fields:
-
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `file` | file | yes | Uploaded video file |
-| `profile` | string | yes | Profile name defined in YAML |
+| `profile` | string | yes | Server-side YAML profile name |
 
-### Behavior
+Behavior:
 
-If `(content_hash, profile)` does not exist:
+- The server streams the file to a temporary path.
+- The server computes SHA-256 while reading the stream.
+- The dedup key is `(content_sha256, profile_name)`.
+- If the key is new, the server creates one canonical job and enqueues it.
+- If the key already exists, the server returns the existing job ID and current job status.
 
-- create new canonical job
-- enqueue job
-- return `deduplicated=false`
-
-If `(content_hash, profile)` already exists:
-
-- do not create a new job
-- do not enqueue
-- return existing `job_id`
-- return `deduplicated=true`
-
-### Response: New Job
+New job response:
 
 ```json
 {
@@ -66,23 +72,43 @@ If `(content_hash, profile)` already exists:
 }
 ```
 
-### Response: Deduplicated Job
+Deduplicated response:
 
 ```json
 {
   "job_id": "uuid",
-  "status": "queued",
+  "status": "running",
   "deduplicated": true,
   "profile": "web_720p",
   "content_hash": "sha256..."
 }
 ```
 
----
+The `status` in a deduplicated response is the existing job's current status. It is not always `queued`.
+
+Success status codes:
+
+| Status | Condition |
+|---:|---|
+| 201 | New canonical job created |
+| 200 | Existing job returned (`deduplicated=true`) |
+
+Deduplication property: for a fixed `(content_sha256, profile_name)`, repeated `POST /api/jobs` calls return the same `job_id` until that job is purged from in-memory state. The first request creates the canonical job with status `queued`; subsequent requests return the same `job_id` along with the canonical job's current status.
+
+Errors:
+
+| Status | Code | Condition |
+|---:|---|---|
+| 400 | `missing_file` | multipart request has no `file` field |
+| 400 | `missing_profile` | multipart request has no `profile` field |
+| 400 | `unknown_profile` | profile name is not configured |
+| 413 | `payload_too_large` | uploaded body exceeds the configured maximum size |
+
+If the client disconnects before upload completion, the server may not be able to send a response. The server-side behavior is still defined: no content hash is finalized, no job metadata is inserted, and no job is enqueued.
 
 ## `GET /api/jobs/{job_id}`
 
-### Response
+Response:
 
 ```json
 {
@@ -100,7 +126,11 @@ If `(content_hash, profile)` already exists:
 }
 ```
 
----
+Errors:
+
+| Status | Code | Condition |
+|---:|---|---|
+| 404 | `unknown_job_id` | no job exists for `job_id` |
 
 ## `GET /api/jobs`
 
@@ -121,8 +151,6 @@ Planned response:
 }
 ```
 
----
-
 ## `GET /api/jobs/{job_id}/artifact`
 
 Downloads the output artifact.
@@ -130,6 +158,22 @@ Downloads the output artifact.
 Rules:
 
 - `succeeded`: return artifact file
-- `queued` / `running`: return not-ready error
-- `failed`: return failure error
-- unknown `job_id`: return 404
+- `queued` or `running`: return artifact-not-ready error
+- `failed`: return job-failed error
+- unknown `job_id`: return not-found error
+
+Successful response headers:
+
+| Header | Value |
+|---|---|
+| `Content-Type` | derived from the profile's `output_extension` (for example `video/mp4` for `mp4`) |
+| `Content-Disposition` | `attachment; filename="{job_id}.{output_extension}"` |
+| `Content-Length` | artifact byte size |
+
+Errors:
+
+| Status | Code | Condition |
+|---:|---|---|
+| 404 | `unknown_job_id` | no job exists for `job_id` |
+| 409 | `artifact_not_ready` | job is still `queued` or `running` |
+| 409 | `job_failed` | job reached `failed` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,164 +1,155 @@
 # Architecture
 
+This document describes the target architecture. The implementation is not yet present in this repository.
+
 ## Overview
 
-Video Digest Server is a concurrent HTTP ingest server written in Rust.
-
-The target architecture is intentionally small:
-
-```text
-HTTP API -> Upload Stream -> Hash + Temp File -> Dedup Registry -> Job Queue -> Worker -> FFmpeg -> Artifact
+```mermaid
+flowchart LR
+    API["Axum HTTP API"] --> UP["Upload Handler"]
+    UP --> TMP["Temp File + SHA-256"]
+    TMP --> REG["Shared Registry"]
+    REG --> QUEUE["Job Queue"]
+    QUEUE --> WORKERS["Worker Pool"]
+    WORKERS --> FFMPEG["FFmpeg Runner"]
+    FFMPEG --> ART["Local Artifact"]
 ```
 
-The system does not use a database. All runtime state is in memory.
-
-This document describes the target design. The implementation is not yet present in this repository.
-
----
+The system does not use a database. Runtime job state is stored in memory, while input files and artifacts are stored on the local filesystem.
 
 ## Components
 
-### 1. HTTP API
+| Component | Responsibility |
+|---|---|
+| HTTP API | Accept uploads, validate profile names, expose job status, expose artifact downloads |
+| Upload Handler | Stream multipart body, write temp file, compute SHA-256, finalize hash after complete upload |
+| Dedup Registry | Ensure one canonical job per `(content_sha256, profile_name)` |
+| Job Queue | Deliver each queued `JobId` to at most one worker |
+| Worker Pool | Move jobs through `queued -> running -> succeeded/failed` |
+| FFmpeg Runner | Build commands from server-side YAML profiles only |
+| Local Storage | Store temporary uploads, canonical inputs, and output artifacts |
 
-Responsibilities:
+## Shared Registry
 
-- accept multipart uploads
-- validate profile name
-- stream file body
-- return job response
-- expose job status
-- expose artifact download
-
-Expected framework:
-
-- Axum
-- Tokio
-
-### 2. Upload Handler
-
-Responsibilities:
-
-- read multipart file stream
-- write bytes to a temporary file
-- compute SHA-256 while reading the stream
-- finalize hash only after the upload completes
-- pass finalized hash to dedup registry
-
-The upload handler must not insert a job before the upload completes.
-
-### 3. Dedup Registry
-
-Responsibilities:
-
-- maintain mapping from `DedupKey` to `DedupEntry`
-- ensure only one canonical job exists for each `(content_hash, profile_name)`
-- prevent check-then-insert race
-
-Target structure:
+Target shared state:
 
 ```rust
+type SharedRegistry = Arc<tokio::sync::Mutex<RegistryState>>;
+
 struct RegistryState {
     dedup: HashMap<DedupKey, DedupEntry>,
     jobs: HashMap<JobId, Job>,
 }
+
+struct DedupKey {
+    content_sha256: String,
+    profile_name: String,
+}
+
+struct DedupEntry {
+    job_id: JobId,
+}
+
+struct Job {
+    job_id: JobId,
+    status: JobStatus,
+    profile_name: String,
+    content_sha256: String,
+    input_path: PathBuf,
+    artifact_path: Option<PathBuf>,
+    error: Option<String>,
+}
 ```
 
-Target synchronization:
+These are target shapes, not final Rust definitions. The important boundary is that `dedup` and `jobs` are mutated through the same `RegistryState` lock.
 
-```rust
-Arc<tokio::sync::Mutex<RegistryState>>
+## Mutex Choice
+
+`tokio::sync::Mutex` is preferred over `std::sync::Mutex` so that a contended `lock().await` does not block the executor thread while waiting for the lock. The "no `.await` while holding the registry lock" rule still applies — that rule is about avoiding deadlocks and long-tail latency under the lock, not about whether the lock itself is async-aware. With async-aware locking and a strict no-await-under-lock policy, contention only delays other tasks rather than blocking executor threads.
+
+## Registry Critical Section
+
+The dedup operation must keep lookup and insertion in one critical section:
+
+```mermaid
+flowchart TD
+    A["compute content hash outside lock"] --> B["lock SharedRegistry"]
+    B --> C{"dedup.entry(key)"}
+    C -->|"occupied"| D["copy existing job snapshot"]
+    C -->|"vacant"| E["create job_id + queued metadata"]
+    E --> F["insert dedup entry"]
+    F --> G["insert job metadata"]
+    D --> H["drop lock"]
+    G --> H
+    H --> I{"created new job?"}
+    I -->|"yes"| J["enqueue JobId outside lock"]
+    I -->|"no"| K["serialize existing response outside lock"]
 ```
 
-### 4. Job Queue
+Rules:
 
-Responsibilities:
+- do not hold the registry lock while awaiting
+- do not hold the registry lock while reading upload streams
+- do not hold the registry lock while writing large files
+- do not hold the registry lock while running FFmpeg
+- do not hold the registry lock while downloading artifacts
+- enqueue new jobs after the registry lock is dropped
+- copy job snapshots under the lock, then serialize `GET /api/jobs` responses after the lock is dropped
 
-- accept only new canonical jobs
-- provide jobs to workers
-- prevent duplicate processing
+## Job Queue Contract
 
-The queue should not receive deduplicated requests.
+The queue receives only canonical jobs. Deduplicated requests must not enqueue work.
 
-### 5. Worker Pool
-
-Responsibilities:
-
-- receive jobs from queue
-- update status from `queued` to `running`
-- execute FFmpeg command
-- update status to `succeeded` or `failed`
-
-### 6. FFmpeg Runner
-
-Responsibilities:
-
-- read profile arguments from YAML profile config
-- build command using argument array
-- run FFmpeg as an external process
-- record success or failure
-
-The client never sends raw FFmpeg arguments.
-
-### 7. Local Storage
-
-Responsibilities:
-
-- store temporary upload files
-- store canonical job input files
-- store output artifacts
-
-Target layout:
+The queue abstraction must guarantee:
 
 ```text
-data/
-  tmp/
-  jobs/
-    {job_id}/
-      input/
-      output/
+one JobId is delivered to at most one worker
 ```
 
----
+A Tokio channel or an equivalent queue can satisfy this contract. Multiple workers may exist, but a single queued job must not be processed by more than one worker.
 
-## Shared State
+## Profile Handling
 
-| State | Owner | Synchronization |
-|---|---|---|
-| dedup map | `RegistryState` | Mutex |
-| job map | `RegistryState` | Mutex |
-| job queue | Queue component | async channel / mutex |
-| profiles | loaded at startup | immutable shared reference |
-| local files | filesystem | unique paths by job ID |
+Profiles are loaded from server-side YAML configuration at startup. The client sends only the profile name.
 
----
+The server must not accept raw FFmpeg arguments from clients.
 
-## Locking Rules
+The profile name is part of the dedup key:
 
-Lock should be held only for small shared-state operations.
+```text
+(content_sha256, profile_name)
+```
 
-Allowed under lock:
-
-- check dedup key
-- insert dedup entry
-- insert job metadata
-- update job status
-- read job metadata
-
-Not allowed under lock:
-
-- reading upload stream
-- hashing large files
-- FFmpeg execution
-- artifact download
-- long polling
-
----
+Runtime profile reload is out of scope.
 
 ## Job State Machine
 
-```text
-queued -> running -> succeeded
-queued -> running -> failed
+```mermaid
+stateDiagram-v2
+    [*] --> queued
+    queued --> running
+    running --> succeeded
+    running --> failed
+    succeeded --> [*]
+    failed --> [*]
 ```
 
-Invalid transitions must be rejected.
+Allowed transitions:
+
+- `queued -> running`
+- `running -> succeeded`
+- `running -> failed`
+
+All other transitions should be rejected.
+
+## Failure Modes
+
+| Failure | Effect | Handling |
+|---|---|---|
+| Upload connection dropped mid-stream | No content hash, no dedup entry, no job metadata | Temp file is discarded |
+| Same content uploaded by another client after a previous interrupted attempt | The previous attempt left no registry entry | The new upload becomes the canonical job |
+| FFmpeg exits non-zero | Job transitions `running -> failed` | `Job.error` stores a stderr summary |
+| Worker crash mid-FFmpeg | Job may remain `running` | Automatic recovery is out of scope |
+| Server restart | All in-memory `RegistryState` is lost | On-disk inputs and artifacts survive but are not auto-reconciled with the new registry |
+
+These are the design contracts; the implementation must keep them in sync with the test plan.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,126 +1,141 @@
 # Test Plan
 
-## Purpose
+This document describes the planned tests. Tests will be implemented along with the server in later PRs.
 
-The tests are designed to prove that the server is safe under concurrent access to shared state.
-
-The primary safety property:
+## Primary Safety Property
 
 ```text
-For the same (content_hash, profile), only one canonical job is created.
+For the same (content_sha256, profile_name), only one canonical job is created.
 ```
 
-This document describes the planned tests. Tests will be implemented along with the server in subsequent PRs.
+## Core Test Order
 
----
+| Order | Test | Level | Purpose |
+|---:|---|---|---|
+| 1 | `tests/dedup_registry_concurrent.rs` | registry integration | Prove atomic check-and-insert under concurrent tasks |
+| 2 | `invalid_status_transition` | unit | Prove the job state machine rejects invalid transitions |
+| 3 | `worker_no_duplicate_processing` | integration | Prove one queued job is processed at most once |
+| 4 | `incomplete_upload_no_job` | integration | Prove interrupted uploads do not register jobs |
+| 5 | `same_filename_different_content` | integration | Prove filenames are not identity |
+| 6 | `same_file_concurrent_upload` | HTTP integration | Prove end-to-end upload dedup after the API exists |
 
-## Test Matrix
+The first implementation milestone should prioritize `tests/dedup_registry_concurrent.rs`. HTTP-level same-file concurrent upload testing can come later, after the upload API exists.
 
-| Test | Level | Purpose |
-|---|---|---|
-| `dedup_registry_concurrent_access` | unit/integration | Verify atomic check-and-insert |
-| `same_file_concurrent_upload` | integration | Verify HTTP-level dedup |
-| `same_filename_different_content` | integration | Verify filename is not identity |
-| `worker_no_duplicate_processing` | integration | Verify one job is not processed twice |
-| `invalid_status_transition` | unit | Verify job state machine |
-| `incomplete_upload_no_job` | integration | Verify dropped request does not create job |
+## 1. `tests/dedup_registry_concurrent.rs`
 
----
+Setup:
 
-## 1. `dedup_registry_concurrent_access`
-
-### Setup
-
-- create shared `RegistryState`
+- create one shared `RegistryState`
+- wrap it in `Arc<tokio::sync::Mutex<_>>`
 - create one `DedupKey`
-- spawn 100 Tokio tasks
-- every task calls `get_or_create(DedupKey)`
+- spawn many Tokio tasks
+- each task calls the registry `get_or_create` operation with the same key
 
-### Expected
+Expected:
 
-- one canonical job
-- all returned job IDs are equal
-- dedup map size is 1
+- exactly one canonical job is created
+- all tasks receive the same `job_id`
+- dedup map size is `1`
+- job map contains one canonical job for the key
+- no task observes a partially inserted registry state
 
----
+To force a tight race window, gate every spawned task on a `tokio::sync::Barrier` so that all `get_or_create` calls fire only after every task has reached the barrier. Without that synchronization the spawn order tends to serialize the calls and the race is rarely exercised, leaving a buggy implementation green.
 
-## 2. `same_file_concurrent_upload`
+## 2. `invalid_status_transition`
 
-### Setup
+Setup:
 
-- start test server
+- create jobs in each supported state
+- attempt valid and invalid transitions
+
+Expected:
+
+- `queued -> running` is accepted
+- `running -> succeeded` is accepted
+- `running -> failed` is accepted
+- terminal states cannot transition back to active states
+- `running -> queued` is rejected
+
+## 3. `worker_no_duplicate_processing`
+
+Setup:
+
+- create multiple queued jobs
+- run multiple workers
+- track processing count by `job_id`
+
+Expected:
+
+- each `job_id` is delivered to at most one worker
+- each processed job reaches `succeeded` or `failed`
+- invalid status transitions do not occur
+
+## 4. `incomplete_upload_no_job`
+
+Setup:
+
+- open a request connection
+- begin multipart upload
+- drop the connection before upload completion
+
+Expected:
+
+- no content hash is finalized
+- no dedup entry is inserted
+- no job metadata is inserted
+- no job is enqueued
+- temporary upload data is removed or ignored
+
+## 5. `same_filename_different_content`
+
+Setup:
+
+- prepare two files with different bytes
+- upload both using the original filename `sample.mp4`
+
+Expected:
+
+- content hashes differ
+- job IDs differ
+- dedup does not use original filename as identity
+
+## 6. `same_file_concurrent_upload`
+
+This is a later HTTP integration test after `POST /api/jobs` exists.
+
+Setup:
+
+- start the test server
 - prepare one small sample file
 - spawn N HTTP clients
 - every client uploads the same file and same profile
 
-### Expected
+Expected:
 
 - all successful responses contain the same `job_id`
 - `deduplicated=false` appears once
 - `deduplicated=true` appears N-1 times
-- FFmpeg / mock transcoder is invoked once
+- FFmpeg or mock transcoder is invoked once
 
----
+## Mock Transcoder
 
-## 3. `same_filename_different_content`
+Tests that exercise the worker pool (`worker_no_duplicate_processing`, `same_file_concurrent_upload`) should run against a mock transcoder rather than spawning real FFmpeg. The mock implements the same trait/interface as the production runner, lets tests assert spawn count, and keeps CI free of FFmpeg installation requirements.
 
-### Setup
+## Coding Rules
 
-- prepare two files with different bytes
-- send both as original filename `sample.mp4`
+- no `unwrap()` or `expect()` outside tests
+- no `.await` while holding the registry mutex guard
+- no FFmpeg execution while holding the registry lock
+- no upload streaming while holding the registry lock
+- enqueue new jobs after dropping the registry lock
+- serialize list-job responses after copying snapshots and dropping the registry lock
 
-### Expected
+## CI Quality Gates
 
-- `content_hash` differs
-- `job_id` differs
-- dedup does not use filename as identity
-
----
-
-## 4. `worker_no_duplicate_processing`
-
-### Setup
-
-- create multiple jobs
-- run multiple workers
-- track processing count by `job_id`
-
-### Expected
-
-- each job is processed at most once
-- terminal state is `succeeded` or `failed`
-- invalid state transition does not occur
-
----
-
-## 5. `incomplete_upload_no_job`
-
-### Setup
-
-- open connection
-- begin upload
-- drop connection before completion
-
-### Expected
-
-- no content hash finalized
-- no dedup entry
-- no job metadata
-- no queue enqueue
-
----
-
-## CI
-
-Minimum required CI command:
-
-```bash
-cargo test --all
-```
-
-Optional:
+Once the Rust scaffold exists, CI should run:
 
 ```bash
 cargo fmt --check
 cargo clippy --all-targets -- -D warnings
+cargo test --all
 ```


### PR DESCRIPTION
## Summary

Follow-up to #1. The first PR established the design baseline; this one tightens the contracts that the upcoming implementation PRs will rely on.

### README

- Add a Failure Handling table covering interrupted upload, the A-drops-then-B-uploads scenario, FFmpeg failure, worker crash, and server restart

### `docs/ARCHITECTURE.md`

- Document the Mutex Choice rationale (`tokio::sync::Mutex` vs `std::sync::Mutex`) so contended `lock().await` does not block executor threads
- Add a Failure Modes table mirroring the README contract

### `docs/API_SPEC.md`

- Success status codes for `POST /api/jobs`: `201` for a new canonical job, `200` for a deduplicated response
- Deduplication property: a fixed `(content_sha256, profile_name)` returns the same `job_id` while the canonical job is alive in memory
- Artifact response headers: `Content-Type`, `Content-Disposition`, `Content-Length`
- New error: `413 payload_too_large`

### `docs/TEST_PLAN.md`

- Document the `tokio::sync::Barrier` pattern for forcing a tight race window in `tests/dedup_registry_concurrent.rs` (without it, spawn order tends to serialize the calls and a buggy implementation can stay green)
- Add a Mock Transcoder section so worker tests do not depend on a real FFmpeg install

## Scope

Documentation only. No Rust code, no `Cargo.toml`, no CI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)