### PR TITLE
fix: recover pipeline - POST enqueue, input staging, worker recv loop

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,6 @@
-use crate::dedup::{RegistryState, RegistryArc};
-use crate::shared::{DedupKey, Job, AppResult};
+use crate::dedup::RegistryArc;
+use crate::queue::JobSender;
+use crate::shared::{DedupKey, Job};
 use crate::storage::Storage;
 use axum::{
     extract::multipart::Multipart,
@@ -7,7 +8,7 @@ use axum::{
     http::StatusCode,
     response::Json,
     routing::{get, post},
-    Json as AxumJson, Router,
+    Router,
 };
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
@@ -16,6 +17,7 @@ use tokio::fs;
 pub struct AppState {
     pub registry: RegistryArc,
     pub storage: Arc<Storage>,
+    pub queue_tx: JobSender,
 }
 
 impl Clone for AppState {
@@ -23,6 +25,7 @@ impl Clone for AppState {
         AppState {
             registry: Arc::clone(&self.registry),
             storage: self.storage.clone(),
+            queue_tx: self.queue_tx.clone(),
         }
     }
 }
@@ -83,16 +86,60 @@ pub async fn create_job(
     // Create DedupKey
     let key = DedupKey::new(content_hash.clone(), profile.clone());
 
-    // Get or create job under lock
+    // Atomic dedup lookup/insert. Synchronous body — no `.await` while holding
+    // the registry guard (docs/ARCHITECTURE.md, docs/TEST_PLAN.md).
     let profile_for_response = profile.clone();
     let (job_id, deduplicated) = {
         let mut registry = state.registry.lock().await;
-        registry.get_or_create(key, profile).await
+        registry.get_or_create(key.clone(), profile)
     };
 
-    // Cleanup temp file
-    if let Err(e) = state.storage.cleanup_tmp(&filename) {
-        eprintln!("Failed to cleanup temp file: {}", e);
+    if deduplicated {
+        // Existing canonical job: discard tmp, do not enqueue.
+        state.storage.cleanup_tmp(&filename).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to cleanup tmp: {}", e),
+            )
+        })?;
+    } else {
+        // New canonical job: stage tmp -> canonical input, then enqueue.
+        // Order: create_job_dirs -> rename -> send. If any step fails after
+        // the registry insert, roll back the dedup/jobs entries so future
+        // requests for the same key can produce a fresh canonical job
+        // (docs/API_SPEC.md: "creates one canonical job and enqueues it").
+        let canonical_path = state.storage.job_input_path(&job_id).join("input.bin");
+        let tmp_path = state.storage.tmp_path(&filename);
+
+        let staging: Result<(), String> = async {
+            state
+                .storage
+                .create_job_dirs(&job_id)
+                .map_err(|e| format!("create_job_dirs: {}", e))?;
+            fs::rename(&tmp_path, &canonical_path)
+                .await
+                .map_err(|e| format!("rename: {}", e))?;
+            state
+                .queue_tx
+                .send(job_id)
+                .map_err(|e| format!("queue send: {}", e))?;
+            Ok(())
+        }
+        .await;
+
+        if let Err(e) = staging {
+            {
+                let mut registry = state.registry.lock().await;
+                registry.remove(&key, &job_id);
+            }
+            // Best-effort tmp cleanup. Ignore errors (tmp may already be
+            // gone if rename succeeded before a later step failed).
+            let _ = state.storage.cleanup_tmp(&filename);
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("staging failed: {}", e),
+            ));
+        }
     }
 
     let response = serde_json::json!({
@@ -193,10 +240,15 @@ pub async fn get_artifact(
     }
 }
 
-pub fn create_router(registry: RegistryArc, storage: Arc<Storage>) -> Router {
+pub fn create_router(
+    registry: RegistryArc,
+    storage: Arc<Storage>,
+    queue_tx: JobSender,
+) -> Router {
     let state = AppState {
         registry,
         storage,
+        queue_tx,
     };
 
     Router::new()

--- a/src/dedup.rs
+++ b/src/dedup.rs
@@ -23,7 +23,7 @@ impl RegistryState {
 
     /// Atomic get-or-create operation under lock.
     /// Returns (job_id, was_deduplicated).
-    pub async fn get_or_create(
+    pub fn get_or_create(
         &mut self,
         key: DedupKey,
         profile: String,
@@ -43,6 +43,17 @@ impl RegistryState {
         self.dedup.insert(key, DedupEntry { job_id });
 
         (job_id, false)
+    }
+
+    /// Roll back a freshly created (key, job_id) when staging or enqueue fails
+    /// before the job becomes effective. Idempotent. The dedup entry is only
+    /// removed if it still points at the same job_id (another canonical job
+    /// may have replaced it under contention; do not clobber that).
+    pub fn remove(&mut self, key: &DedupKey, job_id: &Uuid) {
+        if matches!(self.dedup.get(key), Some(entry) if entry.job_id == *job_id) {
+            self.dedup.remove(key);
+        }
+        self.jobs.remove(job_id);
     }
 
     pub fn get_job(&self, job_id: &Uuid) -> Option<&Job> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,15 +62,21 @@ async fn main() -> Result<()> {
 
     // Initialize shared state
     let registry: RegistryArc = create_registry();
-    let queue = create_queue();
+    let (queue_tx, queue_rx) = create_queue();
     let storage = std::sync::Arc::new(storage);
 
-    // Start worker pool
-    let worker_pool = worker::WorkerPool::new(4, registry.clone(), queue.clone(), ffmpeg_runner, storage.clone());
+    // Start worker pool (consumers share the receiver via Arc<Mutex<_>>)
+    let worker_pool = worker::WorkerPool::new(
+        4,
+        registry.clone(),
+        queue_rx.clone(),
+        ffmpeg_runner,
+        storage.clone(),
+    );
     worker_pool.start().await;
 
-    // Create router
-    let app = api::create_router(registry, storage.clone())
+    // Create router (producer side holds the sender)
+    let app = api::create_router(registry, storage.clone(), queue_tx)
         .layer(TraceLayer::new_for_http());
 
     // Start server

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,44 +1,11 @@
-use crate::shared::Job;
-use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use uuid::Uuid;
 
-pub struct JobQueue {
-    queue: Vec<Uuid>,
-    jobs: HashMap<Uuid, Job>,
-}
+pub type JobSender = mpsc::UnboundedSender<Uuid>;
+pub type JobReceiver = Arc<Mutex<mpsc::UnboundedReceiver<Uuid>>>;
 
-impl JobQueue {
-    pub fn new() -> Self {
-        JobQueue {
-            queue: Vec::new(),
-            jobs: HashMap::new(),
-        }
-    }
-
-    pub async fn enqueue(&mut self, job_id: Uuid, job: Job) {
-        self.queue.push(job_id);
-        self.jobs.insert(job_id, job);
-    }
-
-    pub async fn dequeue(&mut self) -> Option<(Uuid, Job)> {
-        let job_id = self.queue.pop()?;
-        let job = self.jobs.remove(&job_id)?;
-        Some((job_id, job))
-    }
-
-    pub async fn is_empty(&self) -> bool {
-        self.queue.is_empty()
-    }
-
-    pub async fn get_job(&self, job_id: &Uuid) -> Option<&Job> {
-        self.jobs.get(job_id)
-    }
-}
-
-pub type QueueArc = Arc<Mutex<JobQueue>>;
-
-pub fn create_queue() -> QueueArc {
-    Arc::new(Mutex::new(JobQueue::new()))
+pub fn create_queue() -> (JobSender, JobReceiver) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    (tx, Arc::new(Mutex::new(rx)))
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,15 +1,16 @@
 use crate::dedup::RegistryArc;
-use crate::ffmpeg::{FfmpegRunner};
-use crate::queue::QueueArc;
+use crate::ffmpeg::FfmpegRunner;
+use crate::queue::JobReceiver;
 use crate::shared::AppResult;
 use crate::storage::Storage;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct Worker {
     id: usize,
     registry: RegistryArc,
-    queue: QueueArc,
+    queue_rx: JobReceiver,
     ffmpeg_runner: FfmpegRunner,
     storage: Arc<Storage>,
 }
@@ -18,14 +19,14 @@ impl Worker {
     pub fn new(
         id: usize,
         registry: RegistryArc,
-        queue: QueueArc,
+        queue_rx: JobReceiver,
         ffmpeg_runner: FfmpegRunner,
         storage: Arc<Storage>,
     ) -> Self {
         Worker {
             id,
             registry,
-            queue,
+            queue_rx,
             ffmpeg_runner,
             storage,
         }
@@ -33,58 +34,74 @@ impl Worker {
 
     pub async fn run(&self) -> AppResult<()> {
         loop {
-            let (job_id, mut job) = match self.queue.lock().await.dequeue().await {
-                Some((jid, j)) => (jid, j),
-                None => continue,
+            // Receiver is shared across workers via Arc<Mutex<_>>; only one
+            // worker holds the guard at a time, so each enqueued JobId is
+            // delivered to at most one worker (docs/ARCHITECTURE.md Job Queue
+            // Contract). Holding this mutex across `recv().await` is
+            // intentional and distinct from the no-await-under-registry-lock
+            // rule.
+            let job_id = {
+                let mut rx = self.queue_rx.lock().await;
+                match rx.recv().await {
+                    Some(id) => id,
+                    None => break, // all senders dropped
+                }
             };
 
-            // Update status to running
-            {
+            // Snapshot profile + flip to running under a narrow registry
+            // guard. No `.await` inside this block.
+            let profile_name = {
                 let mut registry = self.registry.lock().await;
-                if let Some(j) = registry.jobs.get_mut(&job_id) {
-                    match j.start() {
-                        Ok(()) => {}
-                        Err(_) => {
-                            eprintln!("Failed to set job {} to running", job_id);
-                            continue;
-                        }
-                    }
+                let Some(job) = registry.jobs.get_mut(&job_id) else {
+                    continue;
+                };
+                if job.start().is_err() {
+                    eprintln!("Worker {}: failed to start job {}", self.id, job_id);
+                    continue;
                 }
-            }
+                job.profile.clone()
+            };
 
-            // Run FFmpeg
-            let input_path = self.storage.job_input_path(&job_id);
-            let output_path = self.storage.job_output_path(&job_id).join("proxy.mp4");
-
-            match self
+            // FFmpeg runs without any lock held. Input path must be the
+            // canonical file (data/jobs/{id}/input/input.bin), not the
+            // directory.
+            let input_path: PathBuf = self
+                .storage
+                .job_input_path(&job_id)
+                .join("input.bin");
+            let output_path: PathBuf = self
+                .storage
+                .job_output_path(&job_id)
+                .join("proxy.mp4");
+            let result = self
                 .ffmpeg_runner
-                .run(&input_path, &output_path, &job.profile)
-                .await
-            {
-                Ok(()) => {
-                    let mut registry = self.registry.lock().await;
-                    if let Some(j) = registry.jobs.get_mut(&job_id) {
-                        match j.succeed(output_path) {
-                            Ok(()) => {}
-                            Err(_) => {
-                                eprintln!("Failed to set job {} to succeeded", job_id);
-                            }
+                .run(&input_path, &output_path, &profile_name)
+                .await;
+
+            // Apply terminal status under a narrow registry guard.
+            let mut registry = self.registry.lock().await;
+            if let Some(job) = registry.jobs.get_mut(&job_id) {
+                match result {
+                    Ok(()) => {
+                        if job.succeed(output_path).is_err() {
+                            eprintln!(
+                                "Worker {}: failed to mark job {} succeeded",
+                                self.id, job_id
+                            );
                         }
                     }
-                }
-                Err(e) => {
-                    let mut registry = self.registry.lock().await;
-                    if let Some(j) = registry.jobs.get_mut(&job_id) {
-                        match j.fail(e.to_string()) {
-                            Ok(()) => {}
-                            Err(_) => {
-                                eprintln!("Failed to set job {} to failed", job_id);
-                            }
+                    Err(e) => {
+                        if job.fail(e.to_string()).is_err() {
+                            eprintln!(
+                                "Worker {}: failed to mark job {} failed",
+                                self.id, job_id
+                            );
                         }
                     }
                 }
             }
         }
+        Ok(())
     }
 }
 
@@ -96,13 +113,19 @@ impl WorkerPool {
     pub fn new(
         size: usize,
         registry: RegistryArc,
-        queue: QueueArc,
+        queue_rx: JobReceiver,
         ffmpeg_runner: FfmpegRunner,
         storage: Arc<Storage>,
     ) -> Self {
         let workers = (0..size)
             .map(|id| {
-                Worker::new(id, registry.clone(), queue.clone(), ffmpeg_runner.clone(), storage.clone())
+                Worker::new(
+                    id,
+                    registry.clone(),
+                    queue_rx.clone(),
+                    ffmpeg_runner.clone(),
+                    storage.clone(),
+                )
             })
             .collect();
 

--- a/tests/dedup_registry_concurrent.rs
+++ b/tests/dedup_registry_concurrent.rs
@@ -19,7 +19,7 @@ async fn dedup_registry_concurrent_access() {
         handles.push(tokio::spawn(async move {
             barrier.wait().await;
             let mut r = reg.lock().await;
-            r.get_or_create(key, "p".into()).await
+            r.get_or_create(key, "p".into())
         }));
     }
 


### PR DESCRIPTION
## Summary
- POST `/api/jobs` 핸들러를 워커 파이프라인에 연결: dedup-miss 시 `data/jobs/{id}/input/input.bin`을 `create_job_dirs` + `tokio::fs::rename`으로 staging하고 mpsc로 `job_id`를 송출.
- 워커의 busy-loop dequeue를 공유 `Arc<Mutex<UnboundedReceiver<Uuid>>>` 기반 `recv().await`로 교체. idle 워커 4개 합산 CPU가 ~400% → ~0%로 감소.
- staging 시퀀스(`dirs → rename → send`) 어디서든 실패하면 `RegistryState::remove`로 dedup/jobs entry를 롤백하고 best-effort `cleanup_tmp` 수행. dedup orphan이 영구 잔존해 `docs/API_SPEC.md`의 "create one canonical job and enqueue it" 약속을 깨는 케이스 차단.

## Why
Resolves tkcskmu/syspref-ingest#3 (`[01/10] 파이프라인 복구`). 이슈가 보고한 세 가지 결함 모두 해결:
1. POST 핸들러가 dedup만 하고 enqueue 안 함 → lock drop **후** `queue_tx.send(job_id)`.
2. tmp 파일이 canonical 위치로 이동되지 않고 즉시 삭제됨 → tmp → `data/jobs/{id}/input/input.bin` 이동, `cleanup_tmp`는 dedup-hit 분기로 한정.
3. 빈 큐에서 워커 busy-loop → receiver mutex 위 `recv().await`로 task park.

## Documentation alignment (Source of Truth: `docs/`)
- `docs/ARCHITECTURE.md`: registry guard가 `.await`를 가로지르지 않도록 `RegistryState::get_or_create`를 동기 메서드로 전환. Job Queue Contract("one JobId is delivered to at most one worker")는 receiver mutex 직렬화로 자동 만족. canonical input과 tmp 분리 유지.
- `docs/API_SPEC.md`: 새 key는 canonical job 생성 + enqueue, 기존 key는 enqueue 없이 동일 `job_id` 반환.
- `docs/TEST_PLAN.md`: registry mutex 위에서 `.await`/FFmpeg/upload streaming 금지, enqueue는 lock drop 후.

## User-confirmed policies
- Q1=A: canonical 파일명 = `input.bin` 고정.
- Q2=A: staging/enqueue 실패 시 `RegistryState::remove(key, job_id)` 롤백 + best-effort tmp cleanup + 500.
- Q3=B: dedup-hit 응답 `status` 필드 정확성(R7)은 이슈 #5로 deferral. 이번 PR은 기존 하드코딩 `"queued"` 유지.

## Test plan
- [x] `cargo build` clean (잔존 dead_code 경고 2건은 pre-existing, 이슈 #9 소관)
- [x] `cargo test --all` 5/5 통과 (`dedup_registry_concurrent_access`도 `.await` 제거 후 동등하게 통과)
- [x] 수동: 단일 업로드 → `data/jobs/{id}/input/input.bin` 작성, `data/tmp/` 비어 있음
- [x] 수동: dedup hit → 동일 `job_id`, `deduplicated=true`, 두 번째 tmp 제거됨, canonical 파일 보존
- [x] 수동: idle CPU 0.0% × 3 샘플 (이전 ~400%)
- [x] 수동: rename 실패 강제 주입(`chmod 555 data/jobs`) → HTTP 500 + orphan 제거 → 권한 복구 후 같은 파일 재 POST 시 **새 `job_id`** 발급(rollback 회귀 게이트)
- [ ] 리뷰어 확인: `create_job` 핸들러의 staging 순서가 `dirs → rename → send`인지 (ordering 회귀)
- [ ] 리뷰어 확인: 워커가 ffmpeg에 디렉터리가 아닌 파일 경로(`.../input/input.bin`)를 전달하는지
- [ ] 리뷰어 확인: `cleanup_tmp`가 dedup-hit 분기와 rollback best-effort 경로에서만 호출되는지 (success-path에는 없어야 함 — rename으로 tmp가 사라지므로)
- [ ] 리뷰어 확인: `RegistryState::remove`의 `matches!` 가드가 다른 canonical job이 같은 key를 차지한 경우 dedup map을 보호하는지

## Deferred to other issues
- **#4** (artifact 엔드포인트) — `get_artifact`의 lock-under-await 정정, status code 503/502 → 409, `Content-Type`/`Content-Disposition`/`Content-Length` 헤더, `list_jobs`의 lock-during-serialize 정정, axum 0.7 path-param 라우팅 (`{job_id}` → `:job_id`). 본 PR 리뷰에서 surface된 항목이 #4 plan(Step 8/9)에 포함됨.
- **#5** (응답 JSON shape / status code) — POST `/api/jobs` 201/200 split, dedup-hit `status` 필드를 canonical job의 실제 status로 교체, stable JSON error shape `{ "error": { "code", "message" } }`.
- **#6** (요청 검증) — `missing_file`/`missing_profile`/`unknown_profile`/`payload_too_large` 처리, 클라이언트 multipart filename sanitization.
- **#6/#7** (테스트 스캐폴딩) — `tests/` 디렉터리, mock transcoder, 본 PR의 verbal regression points C-1~C-4(rollback invariant, send-failure rollback, dedup-hit no-worker-invocation, ffmpeg input path)의 자동 검증.
- **#8** — multipart streaming + 점진적 SHA-256.
- **#9** — profile `output_extension` 지원, `cargo fmt --check`, `cargo clippy -D warnings`, `unwrap()` 일괄 제거.
- **별 이슈** — `WorkerPool` graceful shutdown(JoinHandle), EXDEV(다른 마운트 간 rename) fallback, `.gitignore`에 `data/` 추가.

## Files changed (5 files, +160 / -101)
- `src/queue.rs`: `JobQueue`/`QueueArc` 제거 → `JobSender = mpsc::UnboundedSender<Uuid>`, `JobReceiver = Arc<Mutex<UnboundedReceiver<Uuid>>>`, `create_queue() -> (JobSender, JobReceiver)`.
- `src/dedup.rs`: `get_or_create`에서 `async` 제거, 신규 `RegistryState::remove(key, job_id)` (concurrent-safe `matches!` 가드).
- `src/api.rs`: `AppState.queue_tx` 추가, `create_router(reg, storage, queue_tx)` 시그니처 확장, POST 핸들러 `dirs → rename → send` + rollback 분기, `cleanup_tmp` 위치 이동.
- `src/worker.rs`: receiver guard를 좁은 스코프로 잡고 `recv().await`, registry guard도 좁게 분할, ffmpeg 호출 시 `.join("input.bin")`로 파일 경로 전달, `WorkerPool::new` 시그니처 갱신.
- `src/main.rs`: `(queue_tx, queue_rx) = create_queue()`로 분리해 producer/consumer 측에 각각 전달.