### PR TITLE
feat: introduce Transcoder trait and MockTranscoder helper (#8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tokio-util = { version = "0.7", features = ["io"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower-http = { version = "0.5", features = ["trace"] }
+async-trait = "0.1"
 
 [dev-dependencies]
 futures = "0.3"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,8 +26,14 @@ The system does not use a database. Runtime job state is stored in memory, while
 | Dedup Registry | Ensure one canonical job per `(content_sha256, profile_name)` |
 | Job Queue | Deliver each queued `JobId` to at most one worker |
 | Worker Pool | Move jobs through `queued -> running -> succeeded/failed` |
-| FFmpeg Runner | Build commands from server-side YAML profiles only |
+| Transcoder | Worker-facing port. Production adapter is `FfmpegRunner` (builds commands from server-side YAML profiles only). Tests substitute a mock implementation of the same trait |
 | Local Storage | Store temporary uploads, canonical inputs, and output artifacts |
+
+Workers depend on the `Transcoder` trait, not the concrete `FfmpegRunner`.
+Production wires `Arc::new(FfmpegRunner::new(profiles))` into
+`Arc<dyn Transcoder>`; worker-pool tests substitute `MockTranscoder` so CI
+does not require an `ffmpeg` binary (`docs/TEST_PLAN.md` Mock Transcoder
+section).
 
 ## Shared Registry
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,5 @@
 use crate::dedup::RegistryArc;
-use crate::ffmpeg::FfmpegRunner;
+use crate::ffmpeg::Transcoder;
 use crate::queue::JobSender;
 use crate::shared::{DedupKey, Job, JobStatus};
 use crate::storage::Storage;
@@ -22,7 +22,7 @@ pub struct AppState {
     pub registry: RegistryArc,
     pub storage: Arc<Storage>,
     pub queue_tx: JobSender,
-    pub ffmpeg_runner: Arc<FfmpegRunner>,
+    pub transcoder: Arc<dyn Transcoder>,
 }
 
 fn ext_to_mime(ext: &str) -> &'static str {
@@ -256,7 +256,7 @@ pub async fn get_artifact(
                 .ok_or_else(|| internal(format!("profile '{}' artifact missing", job.profile)))?
                 .path;
             let profile = state
-                .ffmpeg_runner
+                .transcoder
                 .get_profile(&job.profile)
                 .ok_or_else(|| internal(format!("profile '{}' missing at runtime", job.profile)))?;
             let ext = profile.output_extension.clone();
@@ -291,13 +291,13 @@ pub fn create_router(
     registry: RegistryArc,
     storage: Arc<Storage>,
     queue_tx: JobSender,
-    ffmpeg_runner: Arc<FfmpegRunner>,
+    transcoder: Arc<dyn Transcoder>,
 ) -> Router {
     let state = AppState {
         registry,
         storage,
         queue_tx,
-        ffmpeg_runner,
+        transcoder,
     };
 
     // axum 0.7 + matchit 0.7 use ":name" path-param syntax; "{name}" is matchit 0.8 / axum 0.8.
@@ -314,7 +314,7 @@ pub fn create_router(
 mod tests {
     use super::*;
     use crate::dedup::create_registry;
-    use crate::ffmpeg::FfmpegProfile;
+    use crate::ffmpeg::{FfmpegProfile, FfmpegRunner};
     use crate::queue::create_queue;
     use crate::shared::Job;
 
@@ -348,7 +348,7 @@ mod tests {
         }
 
         let storage = Arc::new(Storage::new(tmp.path()));
-        let runner = Arc::new(FfmpegRunner::new(vec![FfmpegProfile {
+        let transcoder: Arc<dyn Transcoder> = Arc::new(FfmpegRunner::new(vec![FfmpegProfile {
             name: profile_name.to_string(),
             args: vec![],
             output_extension: ext.to_string(),
@@ -359,7 +359,7 @@ mod tests {
             registry,
             storage,
             queue_tx,
-            ffmpeg_runner: runner,
+            transcoder,
         };
         (state, job_id, tmp)
     }
@@ -407,7 +407,7 @@ mod tests {
         }
 
         let storage = Arc::new(Storage::new(tmp.path()));
-        let runner = Arc::new(FfmpegRunner::new(vec![FfmpegProfile {
+        let transcoder: Arc<dyn Transcoder> = Arc::new(FfmpegRunner::new(vec![FfmpegProfile {
             name: "different_profile".to_string(),
             args: vec![],
             output_extension: "mp4".to_string(),
@@ -417,7 +417,7 @@ mod tests {
             registry,
             storage,
             queue_tx,
-            ffmpeg_runner: runner,
+            transcoder,
         };
 
         let err = get_artifact(State(state), Path(job_id))

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -1,5 +1,7 @@
 use anyhow::{anyhow, Result};
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use std::process::Command;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -39,6 +41,14 @@ pub(crate) fn validate_profiles(profiles: &[FfmpegProfile]) -> Result<()> {
             .map_err(|e| anyhow!("profile '{}': {}", p.name, e))?;
     }
     Ok(())
+}
+
+/// Worker-facing port. Production wires `FfmpegRunner` into `Arc<dyn Transcoder>`;
+/// tests substitute `MockTranscoder`. See `docs/TEST_PLAN.md` Mock Transcoder section.
+#[async_trait]
+pub trait Transcoder: Send + Sync {
+    async fn run(&self, input: &Path, output: &Path, profile: &str) -> Result<()>;
+    fn get_profile(&self, name: &str) -> Option<&FfmpegProfile>;
 }
 
 #[derive(Clone)]
@@ -88,6 +98,17 @@ impl FfmpegRunner {
         } else {
             Err(anyhow!("FFmpeg failed with status: {}", status))
         }
+    }
+}
+
+#[async_trait]
+impl Transcoder for FfmpegRunner {
+    async fn run(&self, input: &Path, output: &Path, profile: &str) -> Result<()> {
+        FfmpegRunner::run(self, input, output, profile).await
+    }
+
+    fn get_profile(&self, name: &str) -> Option<&FfmpegProfile> {
+        FfmpegRunner::get_profile(self, name)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,11 @@ mod worker;
 use anyhow::Result;
 use config::Config;
 use dedup::{create_registry, RegistryArc};
-use ffmpeg::{FfmpegProfile, FfmpegRunner};
+use ffmpeg::{FfmpegProfile, FfmpegRunner, Transcoder};
 use queue::create_queue;
 use std::fs;
 use std::path::Path;
+use std::sync::Arc;
 use storage::Storage;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::layer::SubscriberExt;
@@ -70,25 +71,31 @@ async fn main() -> Result<()> {
         ffmpeg::load_profiles_from_yaml(&profiles_yaml)?
     };
 
-    let ffmpeg_runner = std::sync::Arc::new(FfmpegRunner::new(profiles));
+    // Wire production runner behind the Transcoder port. Both the worker pool
+    // and the artifact handler depend on `Arc<dyn Transcoder>`, not the
+    // concrete `FfmpegRunner`, so tests can substitute a mock with the same
+    // trait surface (docs/TEST_PLAN.md mock transcoder section). The trait
+    // exposes `get_profile`, which the artifact handler uses for the
+    // output_extension lookup added in [07/10].
+    let transcoder: Arc<dyn Transcoder> = Arc::new(FfmpegRunner::new(profiles));
 
     // Initialize shared state
     let registry: RegistryArc = create_registry();
     let (queue_tx, queue_rx) = create_queue();
-    let storage = std::sync::Arc::new(storage);
+    let storage = Arc::new(storage);
 
     // Start worker pool (consumers share the receiver via Arc<Mutex<_>>)
     let worker_pool = worker::WorkerPool::new(
         4,
         registry.clone(),
         queue_rx.clone(),
-        ffmpeg_runner.clone(),
+        transcoder.clone(),
         storage.clone(),
     );
     worker_pool.start().await;
 
-    // Create router (producer side holds the sender + profile lookup)
-    let app = api::create_router(registry, storage.clone(), queue_tx, ffmpeg_runner)
+    // Create router (producer side holds the sender + profile lookup via trait)
+    let app = api::create_router(registry, storage.clone(), queue_tx, transcoder)
         .layer(TraceLayer::new_for_http());
 
     // Start server

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,5 +1,5 @@
 use crate::dedup::RegistryArc;
-use crate::ffmpeg::FfmpegRunner;
+use crate::ffmpeg::Transcoder;
 use crate::queue::JobReceiver;
 use crate::shared::AppResult;
 use crate::storage::Storage;
@@ -15,7 +15,7 @@ pub struct Worker {
     id: usize,
     registry: RegistryArc,
     queue_rx: JobReceiver,
-    ffmpeg_runner: Arc<FfmpegRunner>,
+    transcoder: Arc<dyn Transcoder>,
     storage: Arc<Storage>,
 }
 
@@ -24,14 +24,14 @@ impl Worker {
         id: usize,
         registry: RegistryArc,
         queue_rx: JobReceiver,
-        ffmpeg_runner: Arc<FfmpegRunner>,
+        transcoder: Arc<dyn Transcoder>,
         storage: Arc<Storage>,
     ) -> Self {
         Worker {
             id,
             registry,
             queue_rx,
-            ffmpeg_runner,
+            transcoder,
             storage,
         }
     }
@@ -69,7 +69,7 @@ impl Worker {
             // Resolve output extension from profile. The profile was validated
             // at startup, so a missing entry here is an invariant violation:
             // fail the job rather than silently fall back.
-            let ext = match self.ffmpeg_runner.get_profile(&profile_name) {
+            let ext = match self.transcoder.get_profile(&profile_name) {
                 Some(p) => p.output_extension.clone(),
                 None => {
                     let mut registry = self.registry.lock().await;
@@ -87,7 +87,7 @@ impl Worker {
             let output_dir = self.storage.job_output_path(&job_id);
             let output_path: PathBuf = build_proxy_output_path(&output_dir, &ext);
             let result = self
-                .ffmpeg_runner
+                .transcoder
                 .run(&input_path, &output_path, &profile_name)
                 .await;
 
@@ -124,7 +124,7 @@ impl WorkerPool {
         size: usize,
         registry: RegistryArc,
         queue_rx: JobReceiver,
-        ffmpeg_runner: Arc<FfmpegRunner>,
+        transcoder: Arc<dyn Transcoder>,
         storage: Arc<Storage>,
     ) -> Self {
         let workers = (0..size)
@@ -133,7 +133,7 @@ impl WorkerPool {
                     id,
                     registry.clone(),
                     queue_rx.clone(),
-                    ffmpeg_runner.clone(),
+                    transcoder.clone(),
                     storage.clone(),
                 )
             })

--- a/tests/support/mock_transcoder.rs
+++ b/tests/support/mock_transcoder.rs
@@ -1,0 +1,65 @@
+//! Test helper for the worker pool. Implements `Transcoder` (the
+//! production trait declared in `src/ffmpeg.rs`) without invoking the
+//! real `ffmpeg` binary, so worker-pool tests can run in CI without an
+//! ffmpeg installation (`docs/TEST_PLAN.md` Mock Transcoder section).
+//!
+//! Field/variant names match the issue body exactly: `spawn_count`,
+//! `profiles`, `behavior`, with `MockBehavior::{AlwaysSucceed, AlwaysFail,
+//! Custom}`. `Custom` takes a `Send + Sync` closure so callers can capture
+//! external state (e.g., path log) for assertions.
+
+use async_trait::async_trait;
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use syspref_ingest::ffmpeg::{FfmpegProfile, Transcoder};
+
+pub type CustomFn = Arc<dyn Fn(&Path, &Path, &str) -> anyhow::Result<()> + Send + Sync>;
+
+pub enum MockBehavior {
+    AlwaysSucceed,
+    AlwaysFail,
+    Custom(CustomFn),
+}
+
+pub struct MockTranscoder {
+    pub behavior: MockBehavior,
+    pub spawn_count: Arc<AtomicUsize>,
+    pub profiles: Vec<FfmpegProfile>,
+}
+
+impl MockTranscoder {
+    pub fn new(behavior: MockBehavior, profiles: Vec<FfmpegProfile>) -> Self {
+        Self {
+            behavior,
+            spawn_count: Arc::new(AtomicUsize::new(0)),
+            profiles,
+        }
+    }
+
+    pub fn spawn_count(&self) -> usize {
+        self.spawn_count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Transcoder for MockTranscoder {
+    async fn run(&self, input: &Path, output: &Path, profile: &str) -> anyhow::Result<()> {
+        self.spawn_count.fetch_add(1, Ordering::SeqCst);
+        match &self.behavior {
+            MockBehavior::AlwaysSucceed => {
+                if let Some(parent) = output.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                std::fs::write(output, b"")?;
+                Ok(())
+            }
+            MockBehavior::AlwaysFail => Err(anyhow::anyhow!("mock failure")),
+            MockBehavior::Custom(f) => f(input, output, profile),
+        }
+    }
+
+    fn get_profile(&self, name: &str) -> Option<&FfmpegProfile> {
+        self.profiles.iter().find(|p| p.name == name)
+    }
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub mod mock_transcoder;

--- a/tests/transcoder_smoke.rs
+++ b/tests/transcoder_smoke.rs
@@ -1,0 +1,91 @@
+mod support;
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use support::mock_transcoder::{CustomFn, MockBehavior, MockTranscoder};
+use syspref_ingest::ffmpeg::{FfmpegRunner, Transcoder};
+use uuid::Uuid;
+
+// Compile-only: production `FfmpegRunner` implements `Transcoder` with the
+// `Send + Sync + 'static` bounds required by `Arc<dyn Transcoder>` in
+// `WorkerPool`. ffmpeg binary is NOT executed.
+#[allow(dead_code)]
+fn _assert_transcoder<T: Transcoder + Send + Sync + 'static>(_: &T) {}
+
+#[allow(dead_code)]
+fn _check_ffmpeg_runner_impls_transcoder() {
+    _assert_transcoder(&FfmpegRunner::new(vec![]));
+}
+
+// Compile-only: same `Arc<dyn Transcoder>` coercion main.rs uses for the
+// production wiring also works for the mock.
+#[allow(dead_code)]
+fn _check_arc_dyn_coercion() {
+    let _: Arc<dyn Transcoder> = Arc::new(MockTranscoder::new(MockBehavior::AlwaysSucceed, vec![]));
+}
+
+fn unique_paths() -> (PathBuf, PathBuf) {
+    let id = Uuid::new_v4();
+    let base = std::env::temp_dir().join(format!("syspref-ingest-mock-{}", id));
+    let input = base.join("input.bin");
+    let output = base.join("output").join("proxy.mp4");
+    (input, output)
+}
+
+#[tokio::test]
+async fn always_succeed_increments_spawn_count_and_writes_output() {
+    let mock = MockTranscoder::new(MockBehavior::AlwaysSucceed, vec![]);
+    assert_eq!(mock.spawn_count(), 0);
+
+    let (input, output) = unique_paths();
+    mock.run(&input, &output, "any").await.expect("mock run");
+
+    assert_eq!(mock.spawn_count(), 1);
+    assert!(output.exists(), "AlwaysSucceed should create dummy output");
+
+    // Cleanup
+    if let Some(parent) = output.parent() {
+        let _ = std::fs::remove_dir_all(parent);
+    }
+}
+
+#[tokio::test]
+async fn always_fail_returns_error_and_skips_output() {
+    let mock = MockTranscoder::new(MockBehavior::AlwaysFail, vec![]);
+
+    let (input, output) = unique_paths();
+    let err = mock
+        .run(&input, &output, "any")
+        .await
+        .expect_err("AlwaysFail should error");
+    assert!(err.to_string().contains("mock failure"));
+    assert_eq!(mock.spawn_count(), 1);
+    assert!(!output.exists(), "AlwaysFail must not create output");
+}
+
+#[tokio::test]
+async fn custom_closure_branches_on_profile_and_captures_state() {
+    let captured = Arc::new(AtomicUsize::new(0));
+    let captured_cl = captured.clone();
+    let custom: CustomFn = Arc::new(move |_input, _output, profile| {
+        captured_cl.fetch_add(1, Ordering::SeqCst);
+        if profile == "fail" {
+            Err(anyhow::anyhow!("custom-fail"))
+        } else {
+            Ok(())
+        }
+    });
+    let mock = MockTranscoder::new(MockBehavior::Custom(custom), vec![]);
+
+    let (input, output) = unique_paths();
+    mock.run(&input, &output, "ok").await.expect("ok branch");
+    let err = mock
+        .run(&input, &output, "fail")
+        .await
+        .expect_err("fail branch");
+    assert!(err.to_string().contains("custom-fail"));
+
+    assert_eq!(mock.spawn_count(), 2);
+    assert_eq!(captured.load(Ordering::SeqCst), 2);
+}


### PR DESCRIPTION
## Summary
- 워커가 의존하는 트랜스코딩 경로를 `Transcoder` trait 뒤로 추상화: production은 `Arc::new(FfmpegRunner::new(profiles))`을 `Arc<dyn Transcoder>`로 coercion해서 그대로 동작, 테스트는 동일 trait을 구현하는 `MockTranscoder`로 교체 가능 (`docs/TEST_PLAN.md:120-122` Mock Transcoder 약속 충족).
- `tests/support/mock_transcoder.rs`에 `MockTranscoder` + `MockBehavior { AlwaysSucceed, AlwaysFail, Custom(closure) }` + `pub spawn_count: Arc<AtomicUsize>` 노출. Custom은 `Arc<dyn Fn(&Path,&Path,&str) -> anyhow::Result<()> + Send + Sync>`로 외부 컨테이너 캡처를 허용해 path/state 검증을 후속 PR에 넘김.
- `tests/transcoder_smoke.rs`로 Cargo가 `tests/support/`를 실제로 컴파일하도록 강제 + compile-only assertion(`FfmpegRunner: Transcoder + Send + Sync + 'static`, `Arc<dyn Transcoder>` coercion) + 3 `#[tokio::test]` (AlwaysSucceed / AlwaysFail / Custom 분기).

## Why
Resolves tkcskmu/syspref-ingest#8 (`[06/10] Mock transcoder trait 도입`). 이슈는 `Worker.ffmpeg_runner: FfmpegRunner` (concrete struct) 의존성 탓에 워커 통합 테스트가 실제 ffmpeg 바이너리를 필요로 한다는 문제를 보고. 본 PR은 다음 4개 변경으로 해결:
1. `Transcoder` trait을 `src/ffmpeg.rs`에 정의 — 이슈 본문 1번 그대로(`async fn run(&Path, &Path, &str)` + `fn get_profile`, `Send + Sync` 슈퍼트레잇).
2. `FfmpegRunner`가 trait 구현 — UFCS 위임으로 inherent 메서드 보존, 외부 회귀 위험 0.
3. `Worker`/`WorkerPool`이 `Arc<dyn Transcoder>`를 주입받음 — `#[derive(Clone)]` 그대로 유효(`Arc<T>: Clone` 무관).
4. `MockTranscoder` 헬퍼 추가 — `[05/10]` 워커 통합 테스트가 ffmpeg 없이 검증 가능해짐.

## Documentation alignment (Source of Truth: `docs/`)
- `docs/TEST_PLAN.md:120-122`: "trait/interface as the production runner" 요건 충족 — `MockTranscoder`가 `FfmpegRunner`와 동일 trait 구현.
- `docs/ARCHITECTURE.md`: component 표에 `Transcoder` (worker-facing port) + `FfmpegRunner` (production adapter) + `MockTranscoder` (test substitute) 구도 보강.
- `docs/API_SPEC.md`: 클라이언트 계약과 무관 — trait이 `profile: &str`만 받아 server-side YAML profile 경계 보존, raw ffmpeg args 거부 약속 유지.

## Design choices
- **Trait 위치**: `src/ffmpeg.rs` (이슈 본문 1번 명시). 별도 모듈 분리 안 함.
- **Error 타입**: `anyhow::Result<()>` — 기존 `FfmpegRunner::run`과 동일, worker는 `e.to_string()`만 사용하므로 `AppError` 매핑 실익 없음.
- **Trait object vs generic**: trait object — 워커는 I/O bound라 단형화 이득 없음, `WorkerPool::new` 시그니처 단순화. 이슈 본문도 `Arc<dyn Transcoder>` 명시.
- **`FfmpegRunner` inherent 메서드 보존**: `lib.rs`가 ffmpeg를 pub로 노출하므로 외부 caller 회귀 위험 차단. trait impl은 UFCS(`FfmpegRunner::run(self, ...)`)로 inherent에 위임 — method resolution이 inherent 우선이라 재귀 없음.
- **`MockBehavior::Custom(closure)`**: 이슈 본문 4번 `Custom(...)`을 그대로 따름. closure가 외부 `Arc<Mutex<Vec<...>>>` 등을 캡처하는 패턴으로 `[05/10]` path 검증을 지원하므로 `MockTranscoder.calls` 필드는 미도입(YAGNI).
- **`AlwaysSucceed`의 dummy output 생성**: `?` propagation으로 fs 실패를 silent ignore하지 않도록 처리 — mock의 "성공"이 디버깅 가능하게.
- **`tests/transcoder_smoke.rs` 추가**: 이슈 verification은 `cargo build` + `cargo run`이지만, `tests/support/`만 두면 Cargo가 컴파일하지 않아 mock 자체의 회귀를 못 잡음. smoke test는 mock 동작 한정 — worker pool 검증은 `[05/10]` 스코프.

## Test plan
- [x] `cargo build --all-targets` clean (잔존 dead_code 경고 2건 — `is_terminal`, `AppError` variants — pre-existing, `[09/10]`/#11 소관)
- [x] `cargo test --all` 8/8 통과 (기존 unit 5건 + 신규 smoke 3건: `always_succeed_increments_spawn_count_and_writes_output`, `always_fail_returns_error_and_skips_output`, `custom_closure_branches_on_profile_and_captures_state`)
- [x] compile-only: `_assert_transcoder<T: Transcoder + Send + Sync + 'static>(_: &T)` + `_check_ffmpeg_runner_impls_transcoder` → ffmpeg 실행 없이 `FfmpegRunner: Transcoder` 검증
- [x] compile-only: `let _: Arc<dyn Transcoder> = Arc::new(MockTranscoder::new(...))` → main.rs와 동일 unsized coercion 검증
- [x] production `cargo run` 경로 회귀 없음 — worker의 `self.transcoder.run(...)` 호출은 trait impl이 inherent `FfmpegRunner::run`로 위임, 동작 100% 동일
- [ ] 리뷰어 확인: `Transcoder` 트레잇 슈퍼트레잇 `Send + Sync` + default object lifetime이 `Arc<dyn Transcoder>: Send + Sync + 'static`을 자동 만족 — `WorkerPool::start`의 `tokio::spawn(async move { worker.run().await })`이 컴파일됨이 곧 검증
- [ ] 리뷰어 확인: `MockBehavior::Custom`의 closure 시그니처가 동기 — `[05/10]`이 closure 안에서 async 작업을 원하면 별도 enum variant 추가 필요(현 스코프 외)
- [ ] 리뷰어 확인: `FfmpegRunner` inherent `pub fn get_profile`/`pub async fn run` 보존 — trait method와 동명이지만 `self.run(...)`은 inherent 우선 호출(method resolution), trait dispatch는 UFCS `<FfmpegRunner as Transcoder>::run(...)`로만 발생
- [ ] 리뷰어 확인: `Transcoder::get_profile`의 `#[allow(dead_code)]` — 본 PR 시점엔 caller 없음, `[07/10]`이 first call site (artifact extension derivation)

## Dependencies
- **`[01/10]` (PR #14, `fix/pipeline-recovery`)** 먼저 merge 가정. 본 PR base를 `qcn`으로 두었기 때문에 PR #14가 먼저 머지되면 git patch-id가 본 PR의 cherry-picked commit(`f523d5c`)을 동일 패치로 인식해 자동 정리됨. 만약 본 PR이 PR #14보다 먼저 리뷰 완료되면 manual rebase 필요.

## Deferred to other issues
- **`[05/10]` (PR #13, `jollidah/reverent-moore-f7b088`)** — `tests/worker_no_duplicate_processing.rs`가 `MockTranscoder`를 `Arc<dyn Transcoder>`로 worker pool에 주입해 "one JobId is delivered to at most one worker" invariant 자동 검증. 본 PR이 인터페이스만 제공.
- **`[07/10]` (#9)** — `FfmpegProfile.output_extension` 도입과 함께 `Transcoder::get_profile`의 first call site 등장(artifact 헤더 파생). 본 PR에선 `#[allow(dead_code)]`로 lint 억제.
- **`[09/10]` (#11)** — pre-existing fmt/clippy 위반 (`RegistryState new_without_default`, `JobStatus impl Default → derive`, `WorkerPool::start iter_cloned_collect`, scattered fmt drift, `is_terminal`/`AppError` dead_code) 일괄 정리.