### PR TITLE
feat: derive artifact MIME from profile output_extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ tower-http = { version = "0.5", features = ["trace"] }
 
 [dev-dependencies]
 futures = "0.3"
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -168,6 +168,22 @@ Clients send only a profile name. Raw FFmpeg arguments from clients are not acce
 - local filesystem artifacts
 - focused concurrency and state-machine tests
 
+## Profile Configuration
+
+When `profiles.yaml` exists at the repository root, the server loads it on startup. If the file is absent, hard-coded fallback profiles (`web_720p`, `web_480p`, both `mp4`) are used instead.
+
+A minimal profile entry looks like:
+
+```yaml
+- name: web_720p_webm
+  args: ["-vf", "scale=1280:720", "-c:v", "libvpx-vp9", "-c:a", "libopus"]
+  output_extension: webm
+```
+
+The `output_extension` field is optional and defaults to `mp4`. It must match `^[a-z0-9]{1,8}$` — startup fails if a profile uses a leading dot, uppercase letters, slashes, whitespace, or an empty string. The same value is used for both the worker output filename (`proxy.{output_extension}`) and the artifact download filename (`{job_id}.{output_extension}`).
+
+See [API specification](docs/API_SPEC.md#profile-configuration) for the full schema and the extension-to-MIME mapping used by `GET /api/jobs/{job_id}/artifact`.
+
 ## Out of Scope
 
 - database persistence, including SQLite and PostgreSQL

--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -14,6 +14,24 @@ Clients send only a profile name, for example `web_720p`.
 
 Raw FFmpeg arguments from clients are not accepted. FFmpeg arguments are loaded from server-side YAML profile configuration.
 
+### Profile Configuration
+
+Profiles are loaded at startup from `profiles.yaml` at the repository root (overridable via `--profiles-path`). When the file is absent, the server falls back to built-in profiles (`web_720p`, `web_480p`, both `mp4`).
+
+Each profile entry has the following shape:
+
+```yaml
+- name: web_720p
+  args: ["-vf", "scale=1280:720"]
+  output_extension: mp4
+```
+
+| Field | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `name` | string | yes | — | Profile identifier sent by clients. |
+| `args` | array of strings | yes | — | FFmpeg arguments inserted between input and output paths. |
+| `output_extension` | string | no | `"mp4"` | Used both as the worker output filename `proxy.{output_extension}` and the artifact download filename `{job_id}.{output_extension}`. Must match `^[a-z0-9]{1,8}$` — no leading dot, no uppercase, no slashes, no whitespace, non-empty. The server fails to start if any profile violates this constraint. |
+
 ## Error Shape
 
 Error responses use a stable JSON shape:
@@ -120,7 +138,7 @@ Response:
   "started_at": "2026-04-27T00:00:01Z",
   "finished_at": "2026-04-27T00:00:03Z",
   "artifact": {
-    "path": "data/jobs/{job_id}/output/proxy.mp4"
+    "path": "data/jobs/{job_id}/output/proxy.{output_extension}"
   },
   "error": null
 }
@@ -166,9 +184,18 @@ Successful response headers:
 
 | Header | Value |
 |---|---|
-| `Content-Type` | derived from the profile's `output_extension` (for example `video/mp4` for `mp4`) |
+| `Content-Type` | derived from the profile's `output_extension` (see MIME mapping below) |
 | `Content-Disposition` | `attachment; filename="{job_id}.{output_extension}"` |
 | `Content-Length` | artifact byte size |
+
+MIME mapping from `output_extension` to `Content-Type`:
+
+| `output_extension` | `Content-Type` |
+|---|---|
+| `mp4` | `video/mp4` |
+| `webm` | `video/webm` |
+| `mp3` | `audio/mpeg` |
+| (other) | `application/octet-stream` |
 
 Errors:
 

--- a/profiles.yaml
+++ b/profiles.yaml
@@ -1,0 +1,9 @@
+- name: web_720p
+  args: ["-vf", "scale=1280:720"]
+  output_extension: mp4
+- name: web_480p
+  args: ["-vf", "scale=854:480"]
+  output_extension: mp4
+- name: web_720p_webm
+  args: ["-vf", "scale=1280:720", "-c:v", "libvpx-vp9", "-c:a", "libopus"]
+  output_extension: webm

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,5 @@
 use crate::dedup::RegistryArc;
+use crate::ffmpeg::FfmpegRunner;
 use crate::queue::JobSender;
 use crate::shared::{DedupKey, Job};
 use crate::storage::Storage;
@@ -14,19 +15,20 @@ use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use tokio::fs;
 
+#[derive(Clone)]
 pub struct AppState {
     pub registry: RegistryArc,
     pub storage: Arc<Storage>,
     pub queue_tx: JobSender,
+    pub ffmpeg_runner: Arc<FfmpegRunner>,
 }
 
-impl Clone for AppState {
-    fn clone(&self) -> Self {
-        AppState {
-            registry: Arc::clone(&self.registry),
-            storage: self.storage.clone(),
-            queue_tx: self.queue_tx.clone(),
-        }
+fn ext_to_mime(ext: &str) -> &'static str {
+    match ext {
+        "mp4" => "video/mp4",
+        "webm" => "video/webm",
+        "mp3" => "audio/mpeg",
+        _ => "application/octet-stream",
     }
 }
 
@@ -222,32 +224,48 @@ pub async fn get_artifact(
     State(state): State<AppState>,
     Path(job_id): Path<uuid::Uuid>,
 ) -> Result<axum::response::Response, (StatusCode, String)> {
-    let registry = state.registry.lock().await;
-    let job = registry
-        .get_job(&job_id)
-        .ok_or((StatusCode::NOT_FOUND, format!("Job {} not found", job_id)))?;
+    // Snapshot the job under the registry lock and drop the lock before any I/O.
+    // This satisfies docs/ARCHITECTURE.md:88-97 (no .await while holding the lock).
+    let snapshot = {
+        let registry = state.registry.lock().await;
+        registry.get_job(&job_id).cloned()
+    };
+
+    let job = snapshot.ok_or((StatusCode::NOT_FOUND, format!("Job {} not found", job_id)))?;
 
     match job.status {
         crate::shared::JobStatus::Succeeded => {
-            if let Some(ref artifact) = job.artifact {
-                match fs::read(&artifact.path).await {
-                    Ok(bytes) => {
-                        let mime_str = "video/mp4";
-                        let mime: mime::Mime =
-                            mime_str.parse().unwrap_or(mime::APPLICATION_OCTET_STREAM);
-                        Ok(axum::response::Response::builder()
-                            .header("Content-Type", mime.to_string())
-                            .body(bytes.into())
-                            .unwrap())
-                    }
-                    Err(e) => Err((
+            // The artifact-missing-on-succeeded case keeps the existing 404; full
+            // artifact-endpoint status code alignment is the scope of issue #4.
+            let artifact = job
+                .artifact
+                .as_ref()
+                .ok_or((StatusCode::NOT_FOUND, "Artifact not found".to_string()))?;
+            let profile = state.ffmpeg_runner.get_profile(&job.profile).ok_or((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("profile '{}' missing at runtime", job.profile),
+            ))?;
+            let ext = profile.output_extension.clone();
+            let mime = ext_to_mime(&ext);
+            let bytes = fs::read(&artifact.path).await.map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to read artifact: {}", e),
+                )
+            })?;
+            axum::response::Response::builder()
+                .header("Content-Type", mime)
+                .header(
+                    "Content-Disposition",
+                    format!("attachment; filename=\"{}.{}\"", job.job_id, ext),
+                )
+                .body(bytes.into())
+                .map_err(|e| {
+                    (
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to read artifact: {}", e),
-                    )),
-                }
-            } else {
-                Err((StatusCode::NOT_FOUND, "Artifact not found".to_string()))
-            }
+                        format!("response build failed: {}", e),
+                    )
+                })
         }
         crate::shared::JobStatus::Queued | crate::shared::JobStatus::Running => Err((
             StatusCode::SERVICE_UNAVAILABLE,
@@ -264,11 +282,13 @@ pub fn create_router(
     registry: RegistryArc,
     storage: Arc<Storage>,
     queue_tx: JobSender,
+    ffmpeg_runner: Arc<FfmpegRunner>,
 ) -> Router {
     let state = AppState {
         registry,
         storage,
         queue_tx,
+        ffmpeg_runner,
     };
 
     Router::new()
@@ -278,4 +298,122 @@ pub fn create_router(
         .route("/api/jobs/{job_id}", get(get_job))
         .route("/api/jobs/{job_id}/artifact", get(get_artifact))
         .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dedup::create_registry;
+    use crate::ffmpeg::FfmpegProfile;
+    use crate::queue::create_queue;
+    use crate::shared::Job;
+
+    #[test]
+    fn ext_to_mime_covers_known_and_unmapped_branches() {
+        assert_eq!(ext_to_mime("mp4"), "video/mp4");
+        assert_eq!(ext_to_mime("webm"), "video/webm");
+        assert_eq!(ext_to_mime("mp3"), "audio/mpeg");
+        // Anything that passes `validate_output_extension` but is not in the
+        // known table must still fall back to a usable response type.
+        assert_eq!(ext_to_mime("mov"), "application/octet-stream");
+    }
+
+    fn make_state_with_succeeded_job(
+        ext: &str,
+        profile_name: &str,
+        artifact_bytes: &[u8],
+    ) -> (AppState, uuid::Uuid, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let artifact_path = tmp.path().join(format!("proxy.{}", ext));
+        std::fs::write(&artifact_path, artifact_bytes).expect("write artifact");
+
+        let registry = create_registry();
+        let job_id = uuid::Uuid::new_v4();
+        {
+            let mut reg = registry.try_lock().expect("uncontended");
+            let mut job = Job::new(job_id, profile_name.to_string(), "deadbeef".to_string());
+            job.start().expect("start");
+            job.succeed(artifact_path.clone()).expect("succeed");
+            reg.jobs.insert(job_id, job);
+        }
+
+        let storage = Arc::new(Storage::new(tmp.path()));
+        let runner = Arc::new(FfmpegRunner::new(vec![FfmpegProfile {
+            name: profile_name.to_string(),
+            args: vec![],
+            output_extension: ext.to_string(),
+        }]));
+
+        let (queue_tx, _queue_rx) = create_queue();
+        let state = AppState {
+            registry,
+            storage,
+            queue_tx,
+            ffmpeg_runner: runner,
+        };
+        (state, job_id, tmp)
+    }
+
+    fn header_str<'a>(resp: &'a axum::response::Response, name: &str) -> &'a str {
+        resp.headers()
+            .get(name)
+            .expect("header present")
+            .to_str()
+            .expect("ascii")
+    }
+
+    #[tokio::test]
+    async fn artifact_headers_derive_from_output_extension() {
+        let cases: &[(&str, &str, &str, &[u8])] = &[
+            ("mp4", "web_720p", "video/mp4", b"\0\0\0 ftypmp42"),
+            ("webm", "web_720p_webm", "video/webm", b"\x1aE\xdf\xa3"),
+        ];
+        for (ext, profile_name, mime, bytes) in cases {
+            let (state, job_id, _tmp) = make_state_with_succeeded_job(ext, profile_name, bytes);
+            let resp = get_artifact(State(state), Path(job_id)).await.expect("ok");
+            assert_eq!(header_str(&resp, "Content-Type"), *mime);
+            assert_eq!(
+                header_str(&resp, "Content-Disposition"),
+                format!("attachment; filename=\"{}.{}\"", job_id, ext)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn artifact_handler_returns_500_when_profile_lookup_fails() {
+        // Build state with a profile that does NOT match the job's profile name.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let artifact_path = tmp.path().join("proxy.mp4");
+        std::fs::write(&artifact_path, b"x").expect("write");
+
+        let registry = create_registry();
+        let job_id = uuid::Uuid::new_v4();
+        {
+            let mut reg = registry.try_lock().expect("uncontended");
+            let mut job = Job::new(job_id, "vanished_profile".to_string(), "h".to_string());
+            job.start().expect("start");
+            job.succeed(artifact_path).expect("succeed");
+            reg.jobs.insert(job_id, job);
+        }
+
+        let storage = Arc::new(Storage::new(tmp.path()));
+        let runner = Arc::new(FfmpegRunner::new(vec![FfmpegProfile {
+            name: "different_profile".to_string(),
+            args: vec![],
+            output_extension: "mp4".to_string(),
+        }]));
+        let (queue_tx, _queue_rx) = create_queue();
+        let state = AppState {
+            registry,
+            storage,
+            queue_tx,
+            ffmpeg_runner: runner,
+        };
+
+        let err = get_artifact(State(state), Path(job_id))
+            .await
+            .expect_err("err");
+        assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(err.1.contains("profile 'vanished_profile'"), "{}", err.1);
+    }
 }

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 
@@ -6,6 +6,39 @@ use std::process::Command;
 pub struct FfmpegProfile {
     pub name: String,
     pub args: Vec<String>,
+    #[serde(default = "default_output_extension")]
+    pub output_extension: String,
+}
+
+fn default_output_extension() -> String {
+    "mp4".to_string()
+}
+
+pub(crate) fn validate_output_extension(ext: &str) -> Result<()> {
+    if ext.is_empty() || ext.len() > 8 {
+        return Err(anyhow!(
+            "invalid output_extension '{}': length 1-8 required",
+            ext
+        ));
+    }
+    if !ext
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit())
+    {
+        return Err(anyhow!(
+            "invalid output_extension '{}': only [a-z0-9] allowed (no dot, no uppercase, no slash)",
+            ext
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_profiles(profiles: &[FfmpegProfile]) -> Result<()> {
+    for p in profiles {
+        validate_output_extension(&p.output_extension)
+            .map_err(|e| anyhow!("profile '{}': {}", p.name, e))?;
+    }
+    Ok(())
 }
 
 #[derive(Clone)]
@@ -30,7 +63,7 @@ impl FfmpegRunner {
     ) -> Result<()> {
         let profile = self
             .get_profile(profile_name)
-            .ok_or_else(|| anyhow::anyhow!("Profile not found: {}", profile_name))?;
+            .ok_or_else(|| anyhow!("Profile not found: {}", profile_name))?;
 
         // Convert paths to OsStr for Command
         let input_os = input_path.as_ref().as_os_str();
@@ -53,12 +86,114 @@ impl FfmpegRunner {
         if status.success() {
             Ok(())
         } else {
-            Err(anyhow::anyhow!("FFmpeg failed with status: {}", status))
+            Err(anyhow!("FFmpeg failed with status: {}", status))
         }
     }
 }
 
 pub fn load_profiles_from_yaml(yaml_content: &str) -> Result<Vec<FfmpegProfile>> {
     let profiles: Vec<FfmpegProfile> = serde_yaml::from_str(yaml_content)?;
+    validate_profiles(&profiles)?;
     Ok(profiles)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_profile_with_explicit_mp4() {
+        let yaml = r#"
+- name: web_720p
+  args: ["-vf", "scale=1280:720"]
+  output_extension: mp4
+"#;
+        let profiles = load_profiles_from_yaml(yaml).expect("should load");
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].output_extension, "mp4");
+    }
+
+    #[test]
+    fn deserialize_profile_with_webm() {
+        let yaml = r#"
+- name: web_webm
+  args: ["-c:v", "libvpx-vp9"]
+  output_extension: webm
+"#;
+        let profiles = load_profiles_from_yaml(yaml).expect("should load");
+        assert_eq!(profiles[0].output_extension, "webm");
+    }
+
+    #[test]
+    fn deserialize_profile_with_mp3() {
+        let yaml = r#"
+- name: audio_only
+  args: ["-vn"]
+  output_extension: mp3
+"#;
+        let profiles = load_profiles_from_yaml(yaml).expect("should load");
+        assert_eq!(profiles[0].output_extension, "mp3");
+    }
+
+    #[test]
+    fn deserialize_profile_missing_extension_defaults_to_mp4() {
+        let yaml = r#"
+- name: legacy
+  args: ["-vf", "scale=1280:720"]
+"#;
+        let profiles = load_profiles_from_yaml(yaml).expect("should load");
+        assert_eq!(profiles[0].output_extension, "mp4");
+    }
+
+    #[test]
+    fn validate_accepts_valid_extensions() {
+        for ext in ["mp4", "webm", "mp3", "mov", "m4a", "a", "abcdefgh", "mp4a"] {
+            assert!(
+                validate_output_extension(ext).is_ok(),
+                "expected {ext} to be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_invalid_extensions() {
+        for ext in [
+            "",
+            "abcdefghi",
+            ".webm",
+            "WEBM",
+            "Mp4",
+            "mp 4",
+            "mp4/foo",
+            "mp4\u{4}",
+            "..",
+        ] {
+            assert!(
+                validate_output_extension(ext).is_err(),
+                "expected {ext:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn load_profiles_rejects_invalid_extension_with_profile_name() {
+        let yaml = r#"
+- name: bad_profile
+  args: []
+  output_extension: WEBM
+"#;
+        let err = load_profiles_from_yaml(yaml).expect_err("should fail");
+        let msg = format!("{err}");
+        assert!(msg.contains("bad_profile"), "missing profile name: {msg}");
+        assert!(
+            msg.contains("output_extension"),
+            "missing field name in error: {msg}"
+        );
+    }
+
+    #[test]
+    fn root_profiles_yaml_is_valid() {
+        let yaml = include_str!("../profiles.yaml");
+        load_profiles_from_yaml(yaml).expect("root profiles.yaml should be valid");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,23 +48,29 @@ async fn main() -> Result<()> {
         String::new()
     };
 
-    // Parse profiles (default if empty)
+    // Parse profiles (default if empty). Fallback profiles still need to satisfy
+    // validate_output_extension; YAML-loaded profiles are validated inside
+    // load_profiles_from_yaml so we only re-validate on the fallback path.
     let profiles = if profiles_yaml.is_empty() {
-        vec![
+        let fallback = vec![
             FfmpegProfile {
                 name: "web_720p".to_string(),
                 args: vec!["-vf".to_string(), "scale=1280:720".to_string()],
+                output_extension: "mp4".to_string(),
             },
             FfmpegProfile {
                 name: "web_480p".to_string(),
                 args: vec!["-vf".to_string(), "scale=854:480".to_string()],
+                output_extension: "mp4".to_string(),
             },
-        ]
+        ];
+        ffmpeg::validate_profiles(&fallback)?;
+        fallback
     } else {
         ffmpeg::load_profiles_from_yaml(&profiles_yaml)?
     };
 
-    let ffmpeg_runner = FfmpegRunner::new(profiles);
+    let ffmpeg_runner = std::sync::Arc::new(FfmpegRunner::new(profiles));
 
     // Initialize shared state
     let registry: RegistryArc = create_registry();
@@ -76,13 +82,13 @@ async fn main() -> Result<()> {
         4,
         registry.clone(),
         queue_rx.clone(),
-        ffmpeg_runner,
+        ffmpeg_runner.clone(),
         storage.clone(),
     );
     worker_pool.start().await;
 
-    // Create router (producer side holds the sender)
-    let app = api::create_router(registry, storage.clone(), queue_tx)
+    // Create router (producer side holds the sender + profile lookup)
+    let app = api::create_router(registry, storage.clone(), queue_tx, ffmpeg_runner)
         .layer(TraceLayer::new_for_http());
 
     // Start server

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3,15 +3,19 @@ use crate::ffmpeg::FfmpegRunner;
 use crate::queue::JobReceiver;
 use crate::shared::AppResult;
 use crate::storage::Storage;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+fn build_proxy_output_path(output_dir: &Path, ext: &str) -> PathBuf {
+    output_dir.join(format!("proxy.{}", ext))
+}
 
 #[derive(Clone)]
 pub struct Worker {
     id: usize,
     registry: RegistryArc,
     queue_rx: JobReceiver,
-    ffmpeg_runner: FfmpegRunner,
+    ffmpeg_runner: Arc<FfmpegRunner>,
     storage: Arc<Storage>,
 }
 
@@ -20,7 +24,7 @@ impl Worker {
         id: usize,
         registry: RegistryArc,
         queue_rx: JobReceiver,
-        ffmpeg_runner: FfmpegRunner,
+        ffmpeg_runner: Arc<FfmpegRunner>,
         storage: Arc<Storage>,
     ) -> Self {
         Worker {
@@ -62,17 +66,26 @@ impl Worker {
                 job.profile.clone()
             };
 
+            // Resolve output extension from profile. The profile was validated
+            // at startup, so a missing entry here is an invariant violation:
+            // fail the job rather than silently fall back.
+            let ext = match self.ffmpeg_runner.get_profile(&profile_name) {
+                Some(p) => p.output_extension.clone(),
+                None => {
+                    let mut registry = self.registry.lock().await;
+                    if let Some(j) = registry.jobs.get_mut(&job_id) {
+                        let _ = j.fail(format!("profile '{}' missing at runtime", profile_name));
+                    }
+                    continue;
+                }
+            };
+
             // FFmpeg runs without any lock held. Input path must be the
             // canonical file (data/jobs/{id}/input/input.bin), not the
             // directory.
-            let input_path: PathBuf = self
-                .storage
-                .job_input_path(&job_id)
-                .join("input.bin");
-            let output_path: PathBuf = self
-                .storage
-                .job_output_path(&job_id)
-                .join("proxy.mp4");
+            let input_path: PathBuf = self.storage.job_input_path(&job_id).join("input.bin");
+            let output_dir = self.storage.job_output_path(&job_id);
+            let output_path: PathBuf = build_proxy_output_path(&output_dir, &ext);
             let result = self
                 .ffmpeg_runner
                 .run(&input_path, &output_path, &profile_name)
@@ -92,10 +105,7 @@ impl Worker {
                     }
                     Err(e) => {
                         if job.fail(e.to_string()).is_err() {
-                            eprintln!(
-                                "Worker {}: failed to mark job {} failed",
-                                self.id, job_id
-                            );
+                            eprintln!("Worker {}: failed to mark job {} failed", self.id, job_id);
                         }
                     }
                 }
@@ -114,7 +124,7 @@ impl WorkerPool {
         size: usize,
         registry: RegistryArc,
         queue_rx: JobReceiver,
-        ffmpeg_runner: FfmpegRunner,
+        ffmpeg_runner: Arc<FfmpegRunner>,
         storage: Arc<Storage>,
     ) -> Self {
         let workers = (0..size)
@@ -141,5 +151,27 @@ impl WorkerPool {
                 }
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_proxy_output_path_uses_extension() {
+        let dir = Path::new("/data/jobs/abc/output");
+        assert_eq!(
+            build_proxy_output_path(dir, "mp4"),
+            PathBuf::from("/data/jobs/abc/output/proxy.mp4")
+        );
+        assert_eq!(
+            build_proxy_output_path(dir, "webm"),
+            PathBuf::from("/data/jobs/abc/output/proxy.webm")
+        );
+        assert_eq!(
+            build_proxy_output_path(dir, "mp3"),
+            PathBuf::from("/data/jobs/abc/output/proxy.mp3")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Resolves #9.

- `FfmpegProfile` gains `output_extension: String` (`#[serde(default = "default_output_extension")]`, default `"mp4"`). Startup-time fail-fast validation enforces `^[a-z0-9]{1,8}$` on both the YAML load path and the `main.rs` fallback path.
- `src/worker.rs` no longer hardcodes `proxy.mp4`. A small private `build_proxy_output_path(output_dir, ext)` helper composes `proxy.{ext}` from the profile. Missing profiles at runtime fail the job rather than fall back silently.
- `src/api.rs` `AppState` now carries `Arc<FfmpegRunner>`. `get_artifact` snapshots the job under the registry lock, drops the lock before any I/O, derives `Content-Type` and `Content-Disposition` from the profile's `output_extension` via a private `ext_to_mime` helper (`mp4`/`webm`/`mp3` plus an `application/octet-stream` fallback), and removes the production `unwrap()` calls in the response builder.
- New `profiles.yaml` at the repo root (mp4 x2 + webm with `libvpx-vp9` + `libopus`).
- `docs/API_SPEC.md` documents the YAML profile schema, the format constraint, and the MIME mapping. `README.md` adds a Profile Configuration section explaining the auto-load behavior.

## Out of scope (intentional)

The following artifact-endpoint items remain in issue #4 to keep PR boundaries clean:

- 409 status alignment for `queued` / `running` / `failed`
- `Content-Length` header
- streaming response body
- error envelope shape

## Test plan

- [x] `cargo build` clean (the four `dead_code` warnings are pre-existing in untouched files: `src/queue.rs`, `src/shared.rs`, `src/storage.rs`)
- [x] `cargo test` 23 passed / 0 failed (5 pre-existing + 18 new across `ffmpeg::tests`, `worker::tests`, `api::tests`)
- [x] `cargo fmt --check` clean for touched files (pre-existing fmt drift in untouched files left for the CI quality gate issue)
- [x] `cargo clippy --all-targets` clean for touched files
- [ ] Manual `curl -i .../artifact` verification with the `web_720p_webm` profile (depends on issue #1 [01/10] being merged for the upload + worker pipeline to drive a job to `succeeded`)

## Verification

```
cargo run -- --bind 127.0.0.1:8080 --profiles-path ./profiles.yaml
python client/client.py upload --file client/test_video.mp4 --profile web_720p_webm
curl -i http://localhost:8080/api/jobs/{job_id}/artifact
# expected:
#   Content-Type: video/webm
#   Content-Disposition: attachment; filename="{job_id}.webm"
```