### PR TITLE
[9/10] Apply fmt/clippy and add actions workflow (#11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Tests
+        run: cargo test --all

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,13 +1,12 @@
-use crate::dedup::{RegistryArc, RegistryState};
-use crate::shared::{AppResult, DedupKey, Job};
+use crate::dedup::RegistryArc;
+use crate::shared::{DedupKey, Job};
 use crate::storage::Storage;
 use axum::{
     extract::multipart::Multipart,
     extract::{Path, State},
     http::StatusCode,
     response::Json,
-    routing::{get, post},
-    Json as AxumJson, Router,
+    routing::{get, post}, Router,
 };
 use sha2::{Digest, Sha256};
 use std::sync::Arc;

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,7 +6,8 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Json,
-    routing::{get, post}, Router,
+    routing::{get, post},
+    Router,
 };
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
@@ -15,6 +16,7 @@ use tokio::fs;
 pub struct AppState {
     pub registry: RegistryArc,
     pub storage: Arc<Storage>,
+    pub queue: QueueArc,
 }
 
 impl Clone for AppState {
@@ -212,8 +214,12 @@ pub async fn get_artifact(
     }
 }
 
-pub fn create_router(registry: RegistryArc, storage: Arc<Storage>) -> Router {
-    let state = AppState { registry, storage };
+pub fn create_router(registry: RegistryArc, storage: Arc<Storage>, queue: QueueArc) -> Router {
+    let state = AppState {
+        registry,
+        storage,
+        queue,
+    };
 
     Router::new()
         .route("/api/health", get(health))

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,5 @@
-use crate::dedup::{RegistryState, RegistryArc};
-use crate::shared::{DedupKey, Job, AppResult};
+use crate::dedup::{RegistryArc, RegistryState};
+use crate::shared::{AppResult, DedupKey, Job};
 use crate::storage::Storage;
 use axum::{
     extract::multipart::Multipart,
@@ -39,14 +39,20 @@ pub async fn create_job(
     let mut profile_str: Option<String> = None;
 
     while let Some(field) = multipart.next_field().await.map_err(|e| {
-        (StatusCode::BAD_REQUEST, format!("Failed to read field: {}", e))
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Failed to read field: {}", e),
+        )
     })? {
         let name = field.name().unwrap_or("").to_string();
 
         // Read the bytes using axum's Bytes
         use axum::body::Bytes;
         let bytes: Bytes = field.bytes().await.map_err(|e| {
-            (StatusCode::BAD_REQUEST, format!("Failed to read bytes: {}", e))
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Failed to read bytes: {}", e),
+            )
         })?;
 
         if name == "file" {
@@ -59,14 +65,20 @@ pub async fn create_job(
             let filename = format!("upload_{}.tmp", uuid::Uuid::new_v4());
             let tmp_path = state.storage.tmp_path(&filename);
 
-            fs::write(&tmp_path, &bytes)
-                .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to write file: {}", e)))?;
+            fs::write(&tmp_path, &bytes).await.map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to write file: {}", e),
+                )
+            })?;
 
             file_data = Some((hash, filename));
         } else if name == "profile" {
             profile_str = Some(String::from_utf8(bytes.to_vec()).map_err(|e| {
-                (StatusCode::BAD_REQUEST, format!("Invalid UTF-8 in profile: {}", e))
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Invalid UTF-8 in profile: {}", e),
+                )
             })?);
         }
     }
@@ -141,17 +153,19 @@ pub async fn list_jobs(State(state): State<AppState>) -> Json<serde_json::Value>
 
     let job_list: Vec<serde_json::Value> = jobs
         .iter()
-        .map(|j| serde_json::json!({
-            "job_id": j.job_id.to_string(),
-            "status": match j.status {
-                crate::shared::JobStatus::Queued => "queued",
-                crate::shared::JobStatus::Running => "running",
-                crate::shared::JobStatus::Succeeded => "succeeded",
-                crate::shared::JobStatus::Failed => "failed",
-            },
-            "profile": j.profile,
-            "content_hash": j.content_hash
-        }))
+        .map(|j| {
+            serde_json::json!({
+                "job_id": j.job_id.to_string(),
+                "status": match j.status {
+                    crate::shared::JobStatus::Queued => "queued",
+                    crate::shared::JobStatus::Running => "running",
+                    crate::shared::JobStatus::Succeeded => "succeeded",
+                    crate::shared::JobStatus::Failed => "failed",
+                },
+                "profile": j.profile,
+                "content_hash": j.content_hash
+            })
+        })
         .collect();
 
     Json(serde_json::json!({ "jobs": job_list }))
@@ -172,32 +186,35 @@ pub async fn get_artifact(
                 match fs::read(&artifact.path).await {
                     Ok(bytes) => {
                         let mime_str = "video/mp4";
-                        let mime: mime::Mime = mime_str.parse().unwrap_or(mime::APPLICATION_OCTET_STREAM);
+                        let mime: mime::Mime =
+                            mime_str.parse().unwrap_or(mime::APPLICATION_OCTET_STREAM);
                         Ok(axum::response::Response::builder()
                             .header("Content-Type", mime.to_string())
                             .body(bytes.into())
                             .unwrap())
                     }
-                    Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to read artifact: {}", e))),
+                    Err(e) => Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Failed to read artifact: {}", e),
+                    )),
                 }
             } else {
                 Err((StatusCode::NOT_FOUND, "Artifact not found".to_string()))
             }
         }
-        crate::shared::JobStatus::Queued | crate::shared::JobStatus::Running => {
-            Err((StatusCode::SERVICE_UNAVAILABLE, "Job not completed yet".to_string()))
-        }
-        crate::shared::JobStatus::Failed => {
-            Err((StatusCode::BAD_GATEWAY, format!("Job failed: {:?}", job.error)))
-        }
+        crate::shared::JobStatus::Queued | crate::shared::JobStatus::Running => Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Job not completed yet".to_string(),
+        )),
+        crate::shared::JobStatus::Failed => Err((
+            StatusCode::BAD_GATEWAY,
+            format!("Job failed: {:?}", job.error),
+        )),
     }
 }
 
 pub fn create_router(registry: RegistryArc, storage: Arc<Storage>) -> Router {
-    let state = AppState {
-        registry,
-        storage,
-    };
+    let state = AppState { registry, storage };
 
     Router::new()
         .route("/api/health", get(health))

--- a/src/api.rs
+++ b/src/api.rs
@@ -25,7 +25,7 @@ impl Clone for AppState {
         AppState {
             registry: Arc::clone(&self.registry),
             storage: self.storage.clone(),
-            queue: Arc::clone(&self.queue),
+            queue: self.queue.clone(),
         }
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,5 @@
 use crate::dedup::RegistryArc;
+use crate::queue::QueueArc;
 use crate::shared::{DedupKey, Job};
 use crate::storage::Storage;
 use axum::{
@@ -24,6 +25,7 @@ impl Clone for AppState {
         AppState {
             registry: Arc::clone(&self.registry),
             storage: self.storage.clone(),
+            queue: Arc::clone(&self.queue),
         }
     }
 }

--- a/src/dedup.rs
+++ b/src/dedup.rs
@@ -8,16 +8,17 @@ pub struct DedupEntry {
     pub job_id: Uuid,
 }
 
+#[derive(Default)]
 pub struct RegistryState {
     pub dedup: HashMap<DedupKey, DedupEntry>,
     pub jobs: HashMap<Uuid, Job>,
 }
 
-impl Default for RegistryState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+// impl Default for RegistryState {
+//     fn default() -> Self {
+//         Self::new()
+//     }
+// }
 
 impl RegistryState {
     pub fn new() -> Self {

--- a/src/dedup.rs
+++ b/src/dedup.rs
@@ -14,12 +14,6 @@ pub struct RegistryState {
     pub jobs: HashMap<Uuid, Job>,
 }
 
-// impl Default for RegistryState {
-//     fn default() -> Self {
-//         Self::new()
-//     }
-// }
-
 impl RegistryState {
     pub fn new() -> Self {
         RegistryState {

--- a/src/dedup.rs
+++ b/src/dedup.rs
@@ -13,6 +13,12 @@ pub struct RegistryState {
     pub jobs: HashMap<Uuid, Job>,
 }
 
+impl Default for RegistryState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RegistryState {
     pub fn new() -> Self {
         RegistryState {

--- a/src/dedup.rs
+++ b/src/dedup.rs
@@ -23,11 +23,7 @@ impl RegistryState {
 
     /// Atomic get-or-create operation under lock.
     /// Returns (job_id, was_deduplicated).
-    pub async fn get_or_create(
-        &mut self,
-        key: DedupKey,
-        profile: String,
-    ) -> (Uuid, bool) {
+    pub async fn get_or_create(&mut self, key: DedupKey, profile: String) -> (Uuid, bool) {
         let job_id = Uuid::new_v4();
 
         // Check if we have an existing job with same content_hash
@@ -103,8 +99,7 @@ mod tests {
         // Exactly one should have dedup=false, rest should be true
         let false_count = dedup_flags.iter().filter(|&&x| !x).count();
         assert_eq!(
-            false_count,
-            1,
+            false_count, 1,
             "Exactly one job should be newly created (dedup=false)"
         );
 

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -47,8 +47,9 @@ impl FfmpegRunner {
         let status = tokio::task::spawn_blocking(move || {
             let mut c = child;
             c.wait()
-        }).await??;
-        
+        })
+        .await??;
+
         if status.success() {
             Ok(())
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use queue::create_queue;
 use std::fs;
 use std::path::Path;
 use storage::Storage;
-use tower_http::trace::{TraceLayer};
+use tower_http::trace::TraceLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
@@ -28,17 +28,23 @@ async fn main() -> Result<()> {
         .init();
 
     let config = Config::load()?;
-    
+
     // Initialize storage
     let storage = Storage::new(&config.data_dir);
     storage.ensure_exists()?;
 
     // Load FFmpeg profiles from YAML
-    let profiles_path = config.profiles_path.as_deref().unwrap_or(Path::new("profiles.yaml"));
+    let profiles_path = config
+        .profiles_path
+        .as_deref()
+        .unwrap_or(Path::new("profiles.yaml"));
     let profiles_yaml = if profiles_path.exists() {
         fs::read_to_string(profiles_path)?
     } else {
-        eprintln!("Profiles file not found at {:?}, using defaults", profiles_path);
+        eprintln!(
+            "Profiles file not found at {:?}, using defaults",
+            profiles_path
+        );
         String::new()
     };
 
@@ -66,12 +72,17 @@ async fn main() -> Result<()> {
     let storage = std::sync::Arc::new(storage);
 
     // Start worker pool
-    let worker_pool = worker::WorkerPool::new(4, registry.clone(), queue.clone(), ffmpeg_runner, storage.clone());
+    let worker_pool = worker::WorkerPool::new(
+        4,
+        registry.clone(),
+        queue.clone(),
+        ffmpeg_runner,
+        storage.clone(),
+    );
     worker_pool.start().await;
 
     // Create router
-    let app = api::create_router(registry, storage.clone())
-        .layer(TraceLayer::new_for_http());
+    let app = api::create_router(registry, storage.clone()).layer(TraceLayer::new_for_http());
 
     // Start server
     let addr = config.bind.parse::<std::net::SocketAddr>()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,8 @@ async fn main() -> Result<()> {
     worker_pool.start().await;
 
     // Create router
-    let app = api::create_router(registry, storage.clone()).layer(TraceLayer::new_for_http());
+    let app = api::create_router(registry, storage.clone(), queue.clone())
+        .layer(TraceLayer::new_for_http());
 
     // Start server
     let addr = config.bind.parse::<std::net::SocketAddr>()?;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -9,6 +9,12 @@ pub struct JobQueue {
     jobs: HashMap<Uuid, Job>,
 }
 
+impl Default for JobQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl JobQueue {
     pub fn new() -> Self {
         JobQueue {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -4,18 +4,15 @@ use thiserror::Error;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Default)]
 pub enum JobStatus {
+    #[default]
     Queued,
     Running,
     Succeeded,
     Failed,
 }
 
-impl Default for JobStatus {
-    fn default() -> Self {
-        JobStatus::Queued
-    }
-}
 
 #[derive(Debug, Error)]
 pub enum StatusTransitionError {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -3,8 +3,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub enum JobStatus {
     #[default]
     Queued,
@@ -12,7 +11,6 @@ pub enum JobStatus {
     Succeeded,
     Failed,
 }
-
 
 #[derive(Debug, Error)]
 pub enum StatusTransitionError {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -46,12 +46,12 @@ mod tests {
     fn invalid_status_transition() {
         // Test all invalid transitions
         let invalid_transitions = vec![
-            (JobStatus::Queued, JobStatus::Queued),  // queued -> queued
+            (JobStatus::Queued, JobStatus::Queued),     // queued -> queued
             (JobStatus::Queued, JobStatus::Succeeded),  // queued -> succeeded
-            (JobStatus::Queued, JobStatus::Failed),  // queued -> failed
-            (JobStatus::Running, JobStatus::Running),  // running -> running
-            (JobStatus::Succeeded, JobStatus::Running),  // succeeded -> running
-            (JobStatus::Failed, JobStatus::Running),  // failed -> running
+            (JobStatus::Queued, JobStatus::Failed),     // queued -> failed
+            (JobStatus::Running, JobStatus::Running),   // running -> running
+            (JobStatus::Succeeded, JobStatus::Running), // succeeded -> running
+            (JobStatus::Failed, JobStatus::Running),    // failed -> running
         ];
 
         for (from, to) in invalid_transitions {
@@ -135,7 +135,10 @@ pub struct DedupKey {
 
 impl DedupKey {
     pub fn new(content_hash: String, profile: String) -> Self {
-        DedupKey { content_hash, profile }
+        DedupKey {
+            content_hash,
+            profile,
+        }
     }
 }
 
@@ -183,7 +186,9 @@ impl Job {
         self.status.can_transition_to(JobStatus::Succeeded)?;
         self.status = JobStatus::Succeeded;
         self.finished_at = Some(chrono::Utc::now());
-        self.artifact = Some(Artifact { path: artifact_path });
+        self.artifact = Some(Artifact {
+            path: artifact_path,
+        });
         Ok(())
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -24,11 +24,17 @@ impl Storage {
     }
 
     pub fn job_input_path(&self, job_id: &Uuid) -> PathBuf {
-        self.base_path.join("jobs").join(job_id.to_string()).join("input")
+        self.base_path
+            .join("jobs")
+            .join(job_id.to_string())
+            .join("input")
     }
 
     pub fn job_output_path(&self, job_id: &Uuid) -> PathBuf {
-        self.base_path.join("jobs").join(job_id.to_string()).join("output")
+        self.base_path
+            .join("jobs")
+            .join(job_id.to_string())
+            .join("output")
     }
 
     pub fn create_job_dirs(&self, job_id: &Uuid) -> Result<()> {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,5 +1,5 @@
 use crate::dedup::RegistryArc;
-use crate::ffmpeg::{FfmpegRunner};
+use crate::ffmpeg::FfmpegRunner;
 use crate::queue::QueueArc;
 use crate::shared::AppResult;
 use crate::storage::Storage;
@@ -102,7 +102,13 @@ impl WorkerPool {
     ) -> Self {
         let workers = (0..size)
             .map(|id| {
-                Worker::new(id, registry.clone(), queue.clone(), ffmpeg_runner.clone(), storage.clone())
+                Worker::new(
+                    id,
+                    registry.clone(),
+                    queue.clone(),
+                    ffmpeg_runner.clone(),
+                    storage.clone(),
+                )
             })
             .collect();
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -33,7 +33,7 @@ impl Worker {
 
     pub async fn run(&self) -> AppResult<()> {
         loop {
-            let (job_id, mut job) = match self.queue.lock().await.dequeue().await {
+            let (job_id, job) = match self.queue.lock().await.dequeue().await {
                 Some((jid, j)) => (jid, j),
                 None => continue,
             };
@@ -116,7 +116,7 @@ impl WorkerPool {
     }
 
     pub async fn start(&self) {
-        let workers: Vec<_> = self.workers.iter().cloned().collect();
+        let workers: Vec<_> = self.workers.to_vec();
         for worker in workers {
             tokio::spawn(async move {
                 if let Err(e) = worker.run().await {


### PR DESCRIPTION
Addresses #11 
- Implements actions workflow for fmt, clippy, and tests.
- Applied `cargo fmt` and `clippy --fix`
