### PR TITLE
feat: align response JSON shape and status codes with API spec (#5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ chrono = { version = "0.4", features = ["serde"] }
 hex = "0.4"
 mime = "0.3"
 thiserror = "1"
-tower = "0.4"
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -27,3 +26,4 @@ async-trait = "0.1"
 [dev-dependencies]
 futures = "0.3"
 tempfile = "3"
+tower = { version = "0.4", features = ["util"] }

--- a/client/client.py
+++ b/client/client.py
@@ -36,12 +36,18 @@ def print_job_status(status: JobStatusResponse) -> None:
         print(f"  Error: {status.error}")
 
 
-def format_timestamp(dt_str: str) -> str:
-    """Format ISO timestamp for display."""
-    if dt_str is None:
+def format_timestamp(value) -> str:
+    """Format an ISO timestamp for display.
+
+    Accepts either a `datetime` (the shape produced by ``JobStatusResponse``)
+    or a raw ISO string. ``datetime`` objects also have a ``replace`` method
+    but its signature collides with ``str.replace``; routing through
+    ``isoformat()`` first avoids that footgun.
+    """
+    if value is None:
         return "-"
-    # Remove timezone info for cleaner display
-    return dt_str.replace("Z", "").replace("+00:00", "")
+    s = value.isoformat() if hasattr(value, "isoformat") else str(value)
+    return s.replace("Z", "").replace("+00:00", "")
 
 
 async def cmd_upload(client: VideoDigestClient, args: argparse.Namespace) -> int:

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,14 +1,14 @@
 use crate::dedup::RegistryArc;
 use crate::ffmpeg::Transcoder;
 use crate::queue::JobSender;
-use crate::shared::{DedupKey, Job, JobStatus};
+use crate::shared::{AppError, DedupKey, Job, JobStatus};
 use crate::storage::Storage;
 use axum::{
-    body::Body,
+    body::{Body, Bytes},
     extract::multipart::Multipart,
     extract::{Path, State},
     http::{header, StatusCode},
-    response::Json,
+    response::{Json, Response},
     routing::{get, post},
     Router,
 };
@@ -34,6 +34,15 @@ fn ext_to_mime(ext: &str) -> &'static str {
     }
 }
 
+fn status_str(status: JobStatus) -> &'static str {
+    match status {
+        JobStatus::Queued => "queued",
+        JobStatus::Running => "running",
+        JobStatus::Succeeded => "succeeded",
+        JobStatus::Failed => "failed",
+    }
+}
+
 pub async fn health() -> Json<serde_json::Value> {
     Json(serde_json::json!({"status": "ok"}))
 }
@@ -41,89 +50,59 @@ pub async fn health() -> Json<serde_json::Value> {
 pub async fn create_job(
     State(state): State<AppState>,
     mut multipart: Multipart,
-) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let mut file_data = None;
+) -> Result<(StatusCode, Json<serde_json::Value>), AppError> {
+    let mut file_data: Option<(String, String)> = None;
     let mut profile_str: Option<String> = None;
 
-    while let Some(field) = multipart.next_field().await.map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("Failed to read field: {}", e),
-        )
-    })? {
+    // Multipart parse failures map best-effort to MissingFile/MissingProfile;
+    // #6 (input validation) will tighten the wire-protocol error mapping.
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|_| AppError::MissingFile)?
+    {
         let name = field.name().unwrap_or("").to_string();
-
-        // Read the bytes using axum's Bytes
-        use axum::body::Bytes;
-        let bytes: Bytes = field.bytes().await.map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Failed to read bytes: {}", e),
-            )
-        })?;
+        let bytes: Bytes = field.bytes().await.map_err(|_| AppError::MissingFile)?;
 
         if name == "file" {
-            // Compute SHA-256 while reading
             let mut hasher = Sha256::new();
             hasher.update(&bytes);
             let hash = hex::encode(hasher.finalize());
 
-            // Write to temp file
             let filename = format!("upload_{}.tmp", uuid::Uuid::new_v4());
             let tmp_path = state.storage.tmp_path(&filename);
-
-            fs::write(&tmp_path, &bytes).await.map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to write file: {}", e),
-                )
-            })?;
+            fs::write(&tmp_path, &bytes).await?;
 
             file_data = Some((hash, filename));
         } else if name == "profile" {
-            profile_str = Some(String::from_utf8(bytes.to_vec()).map_err(|e| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("Invalid UTF-8 in profile: {}", e),
-                )
-            })?);
+            profile_str =
+                Some(String::from_utf8(bytes.to_vec()).map_err(|_| AppError::MissingProfile)?);
         }
     }
 
-    let (content_hash, filename) = file_data.ok_or((
-        StatusCode::BAD_REQUEST,
-        "Missing required field: file".to_string(),
-    ))?;
-    let profile = profile_str.ok_or((
-        StatusCode::BAD_REQUEST,
-        "Missing required field: profile".to_string(),
-    ))?;
+    let (content_hash, filename) = file_data.ok_or(AppError::MissingFile)?;
+    let profile = profile_str.ok_or(AppError::MissingProfile)?;
 
-    // Create DedupKey
     let key = DedupKey::new(content_hash.clone(), profile.clone());
-
-    // Atomic dedup lookup/insert. Synchronous body — no `.await` while holding
-    // the registry guard (docs/ARCHITECTURE.md, docs/TEST_PLAN.md).
     let profile_for_response = profile.clone();
-    let (job_id, deduplicated) = {
+
+    // Atomic dedup lookup/insert. Sync body — no `.await` while holding the
+    // registry guard (docs/ARCHITECTURE.md, docs/TEST_PLAN.md).
+    let (job_id, deduplicated, dedup_status) = {
         let mut registry = state.registry.lock().await;
         registry.get_or_create(key.clone(), profile)
     };
 
     if deduplicated {
         // Existing canonical job: discard tmp, do not enqueue.
-        state.storage.cleanup_tmp(&filename).map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to cleanup tmp: {}", e),
-            )
-        })?;
+        if let Err(e) = state.storage.cleanup_tmp(&filename) {
+            return Err(AppError::StorageError(format!("cleanup_tmp: {}", e)));
+        }
     } else {
         // New canonical job: stage tmp -> canonical input, then enqueue.
         // Order: create_job_dirs -> rename -> send. If any step fails after
-        // the registry insert, roll back the dedup/jobs entries so future
-        // requests for the same key can produce a fresh canonical job
-        // (docs/API_SPEC.md: "creates one canonical job and enqueues it").
+        // the registry insert, roll back so future requests for the same key
+        // can produce a fresh canonical job.
         let canonical_path = state.storage.job_input_path(&job_id).join("input.bin");
         let tmp_path = state.storage.tmp_path(&filename);
 
@@ -148,46 +127,42 @@ pub async fn create_job(
                 let mut registry = state.registry.lock().await;
                 registry.remove(&key, &job_id);
             }
-            // Best-effort tmp cleanup. Ignore errors (tmp may already be
-            // gone if rename succeeded before a later step failed).
             let _ = state.storage.cleanup_tmp(&filename);
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("staging failed: {}", e),
-            ));
+            return Err(AppError::StorageError(format!("staging failed: {}", e)));
         }
     }
 
-    let response = serde_json::json!({
+    // Spec: 201 for new canonical job, 200 for dedup hit. `dedup_status` is
+    // already correct in both cases — `JobStatus::Queued` on a fresh insert,
+    // the existing job's current state on a hit.
+    let status_code = if deduplicated {
+        StatusCode::OK
+    } else {
+        StatusCode::CREATED
+    };
+
+    let body = serde_json::json!({
         "job_id": job_id.to_string(),
-        "status": "queued",
+        "status": status_str(dedup_status),
         "deduplicated": deduplicated,
         "profile": profile_for_response,
-        "content_hash": content_hash
+        "content_hash": content_hash,
     });
 
-    Ok(Json(response))
-}
-
-fn status_str(status: JobStatus) -> &'static str {
-    match status {
-        JobStatus::Queued => "queued",
-        JobStatus::Running => "running",
-        JobStatus::Succeeded => "succeeded",
-        JobStatus::Failed => "failed",
-    }
+    Ok((status_code, Json(body)))
 }
 
 pub async fn get_job(
     State(state): State<AppState>,
     Path(job_id): Path<uuid::Uuid>,
-) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    // docs/ARCHITECTURE.md: snapshot under lock, then serialize after lock drops.
-    let job = {
+) -> Result<Json<serde_json::Value>, AppError> {
+    // Snapshot under lock, drop guard, then serialize
+    // (docs/ARCHITECTURE.md: "serialize responses after dropping the lock").
+    let snapshot = {
         let registry = state.registry.lock().await;
         registry.get_job(&job_id).cloned()
-    }
-    .ok_or((StatusCode::NOT_FOUND, format!("unknown_job_id: {}", job_id)))?;
+    };
+    let job = snapshot.ok_or(AppError::JobNotFound(job_id))?;
 
     Ok(Json(serde_json::json!({
         "job_id": job.job_id.to_string(),
@@ -197,7 +172,9 @@ pub async fn get_job(
         "created_at": job.created_at.to_rfc3339(),
         "started_at": job.started_at.map(|t| t.to_rfc3339()),
         "finished_at": job.finished_at.map(|t| t.to_rfc3339()),
-        "artifact": job.artifact.as_ref().map(|a| a.path.display().to_string()),
+        "artifact": job.artifact.as_ref().map(|a| serde_json::json!({
+            "path": a.path.display().to_string()
+        })),
         "error": job.error,
     })))
 }
@@ -227,53 +204,39 @@ pub async fn list_jobs(State(state): State<AppState>) -> Json<serde_json::Value>
 pub async fn get_artifact(
     State(state): State<AppState>,
     Path(job_id): Path<uuid::Uuid>,
-) -> Result<axum::response::Response, (StatusCode, String)> {
+) -> Result<Response, AppError> {
     // docs/ARCHITECTURE.md: snapshot under lock, drop guard before any .await.
-    let job = {
+    let snapshot = {
         let registry = state.registry.lock().await;
         registry.get_job(&job_id).cloned()
-    }
-    .ok_or((StatusCode::NOT_FOUND, format!("unknown_job_id: {}", job_id)))?;
-
-    let internal = |msg: String| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("internal_error: {}", msg),
-        )
     };
+    let job = snapshot.ok_or(AppError::JobNotFound(job_id))?;
 
     match job.status {
-        JobStatus::Queued | JobStatus::Running => {
-            Err((StatusCode::CONFLICT, "artifact_not_ready".to_string()))
-        }
-        JobStatus::Failed => Err((
-            StatusCode::CONFLICT,
-            format!("job_failed: {}", job.error.as_deref().unwrap_or("")),
-        )),
+        JobStatus::Queued | JobStatus::Running => Err(AppError::ArtifactNotReady),
+        JobStatus::Failed => Err(AppError::JobFailed),
         JobStatus::Succeeded => {
+            // Normal flow always sets artifact when transitioning to Succeeded;
+            // surface a stable error if the invariant is violated.
             let path = job
                 .artifact
-                .ok_or_else(|| internal(format!("profile '{}' artifact missing", job.profile)))?
+                .ok_or_else(|| {
+                    AppError::FfmpegError(format!("artifact missing for job '{}'", job.job_id))
+                })?
                 .path;
-            let profile = state
-                .transcoder
-                .get_profile(&job.profile)
-                .ok_or_else(|| internal(format!("profile '{}' missing at runtime", job.profile)))?;
+            let profile = state.transcoder.get_profile(&job.profile).ok_or_else(|| {
+                AppError::FfmpegError(format!("profile '{}' missing at runtime", job.profile))
+            })?;
             let ext = profile.output_extension.clone();
             let mime = ext_to_mime(&ext);
 
             // Stream the artifact to avoid loading large files into memory.
             // Body::from_stream does not set Content-Length; do it explicitly.
-            let len = fs::metadata(&path)
-                .await
-                .map_err(|e| internal(e.to_string()))?
-                .len();
-            let file = fs::File::open(&path)
-                .await
-                .map_err(|e| internal(e.to_string()))?;
+            let len = fs::metadata(&path).await?.len();
+            let file = fs::File::open(&path).await?;
             let body = Body::from_stream(ReaderStream::new(file));
 
-            axum::response::Response::builder()
+            Response::builder()
                 .status(StatusCode::OK)
                 .header(header::CONTENT_TYPE, mime)
                 .header(
@@ -282,7 +245,7 @@ pub async fn get_artifact(
                 )
                 .header(header::CONTENT_LENGTH, len.to_string())
                 .body(body)
-                .map_err(|e| internal(e.to_string()))
+                .map_err(|e| AppError::FfmpegError(format!("response build: {}", e)))
         }
     }
 }
@@ -315,24 +278,108 @@ mod tests {
     use super::*;
     use crate::dedup::create_registry;
     use crate::ffmpeg::{FfmpegProfile, FfmpegRunner};
-    use crate::queue::create_queue;
-    use crate::shared::Job;
+    use crate::queue::{create_queue, JobReceiver};
+    use axum::body::to_bytes;
+    use axum::http::Request;
+    use axum::response::IntoResponse;
+    use tower::ServiceExt;
+
+    // ---------- helpers ----------
+
+    fn test_transcoder() -> Arc<dyn Transcoder> {
+        Arc::new(FfmpegRunner::new(vec![FfmpegProfile {
+            name: "p".to_string(),
+            args: vec![],
+            output_extension: "mp4".to_string(),
+        }]))
+    }
+
+    fn router() -> (Router, RegistryArc, Arc<Storage>, JobReceiver) {
+        let registry = create_registry();
+        let tmp = std::env::temp_dir().join(format!("syspref_test_{}", uuid::Uuid::new_v4()));
+        let storage = Arc::new(Storage::new(&tmp));
+        storage.ensure_exists().unwrap();
+        let (queue_tx, queue_rx) = create_queue();
+        let app = create_router(
+            registry.clone(),
+            storage.clone(),
+            queue_tx,
+            test_transcoder(),
+        );
+        // Return queue_rx so it stays alive in the test scope; otherwise
+        // queue_tx.send() in create_job's staging fails with channel closed.
+        (app, registry, storage, queue_rx)
+    }
+
+    fn multipart_body(boundary: &str, file_bytes: &[u8], profile: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"v.mp4\"\r\n\r\n",
+        );
+        body.extend_from_slice(file_bytes);
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"profile\"\r\n\r\n");
+        body.extend_from_slice(profile.as_bytes());
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    fn multipart_only_profile(boundary: &str, profile: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"profile\"\r\n\r\n");
+        body.extend_from_slice(profile.as_bytes());
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    fn multipart_only_file(boundary: &str, file_bytes: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"v.mp4\"\r\n\r\n",
+        );
+        body.extend_from_slice(file_bytes);
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    async fn read_json(resp: axum::response::Response) -> (StatusCode, serde_json::Value) {
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+            panic!(
+                "expected JSON body but got status {} body {:?}: {}",
+                status,
+                String::from_utf8_lossy(&bytes),
+                e
+            )
+        });
+        (status, v)
+    }
+
+    // ---------- ext_to_mime (PR #18 regression) ----------
 
     #[test]
     fn ext_to_mime_covers_known_and_unmapped_branches() {
         assert_eq!(ext_to_mime("mp4"), "video/mp4");
         assert_eq!(ext_to_mime("webm"), "video/webm");
         assert_eq!(ext_to_mime("mp3"), "audio/mpeg");
-        // Anything that passes `validate_output_extension` but is not in the
-        // known table must still fall back to a usable response type.
         assert_eq!(ext_to_mime("mov"), "application/octet-stream");
     }
+
+    // ---------- direct-handler artifact tests (PR #18 / #4 regression) ----------
 
     fn make_state_with_succeeded_job(
         ext: &str,
         profile_name: &str,
         artifact_bytes: &[u8],
-    ) -> (AppState, uuid::Uuid, tempfile::TempDir) {
+    ) -> (AppState, uuid::Uuid, tempfile::TempDir, JobReceiver) {
         let tmp = tempfile::tempdir().expect("tempdir");
         let artifact_path = tmp.path().join(format!("proxy.{}", ext));
         std::fs::write(&artifact_path, artifact_bytes).expect("write artifact");
@@ -353,15 +400,14 @@ mod tests {
             args: vec![],
             output_extension: ext.to_string(),
         }]));
-
-        let (queue_tx, _queue_rx) = create_queue();
+        let (queue_tx, queue_rx) = create_queue();
         let state = AppState {
             registry,
             storage,
             queue_tx,
             transcoder,
         };
-        (state, job_id, tmp)
+        (state, job_id, tmp, queue_rx)
     }
 
     fn header_str<'a>(resp: &'a axum::response::Response, name: &str) -> &'a str {
@@ -379,7 +425,8 @@ mod tests {
             ("webm", "web_720p_webm", "video/webm", b"\x1aE\xdf\xa3"),
         ];
         for (ext, profile_name, mime, bytes) in cases {
-            let (state, job_id, _tmp) = make_state_with_succeeded_job(ext, profile_name, bytes);
+            let (state, job_id, _tmp, _rx) =
+                make_state_with_succeeded_job(ext, profile_name, bytes);
             let resp = get_artifact(State(state), Path(job_id)).await.expect("ok");
             assert_eq!(header_str(&resp, "Content-Type"), *mime);
             assert_eq!(
@@ -389,9 +436,10 @@ mod tests {
         }
     }
 
+    /// When profile lookup fails the handler must still return 500, but the
+    /// envelope must not leak the profile name or any other internal detail.
     #[tokio::test]
-    async fn artifact_handler_returns_500_when_profile_lookup_fails() {
-        // Build state with a profile that does NOT match the job's profile name.
+    async fn artifact_500_envelope_hides_profile_lookup_detail() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let artifact_path = tmp.path().join("proxy.mp4");
         std::fs::write(&artifact_path, b"x").expect("write");
@@ -405,7 +453,6 @@ mod tests {
             job.succeed(artifact_path).expect("succeed");
             reg.jobs.insert(job_id, job);
         }
-
         let storage = Arc::new(Storage::new(tmp.path()));
         let transcoder: Arc<dyn Transcoder> = Arc::new(FfmpegRunner::new(vec![FfmpegProfile {
             name: "different_profile".to_string(),
@@ -423,7 +470,251 @@ mod tests {
         let err = get_artifact(State(state), Path(job_id))
             .await
             .expect_err("err");
-        assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
-        assert!(err.1.contains("profile 'vanished_profile'"), "{}", err.1);
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["code"], "internal_error");
+        assert_eq!(body["error"]["message"], "internal server error");
+        assert!(!body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("vanished_profile"));
+    }
+
+    // ---------- HTTP-level acceptance for issue #5 ----------
+
+    #[tokio::test]
+    async fn post_new_job_returns_201_and_queued() {
+        let (app, _registry, _storage, _queue_rx) = router();
+        let boundary = "BNDRY";
+        let body = multipart_body(boundary, b"hello world", "p");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/jobs")
+            .header(
+                "Content-Type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(axum::body::Body::from(body))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(body["deduplicated"], serde_json::json!(false));
+        assert_eq!(body["status"], "queued");
+        assert_eq!(body["profile"], "p");
+        assert!(body["job_id"].as_str().is_some());
+        assert!(body["content_hash"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn post_dedup_returns_200_and_current_status() {
+        let (app, registry, _storage, _queue_rx) = router();
+        let boundary = "BNDRY";
+        let body = multipart_body(boundary, b"same content", "p");
+
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/api/jobs")
+                .header(
+                    "Content-Type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                )
+                .body(axum::body::Body::from(body.clone()))
+                .unwrap()
+        };
+
+        let resp1 = app.clone().oneshot(make_req()).await.unwrap();
+        let (status1, body1) = read_json(resp1).await;
+        assert_eq!(status1, StatusCode::CREATED);
+        let job_id = body1["job_id"].as_str().unwrap().to_string();
+
+        // Manually transition the canonical job to Running so we can prove
+        // the dedup response carries the *current* status (not "queued").
+        {
+            let id = uuid::Uuid::parse_str(&job_id).unwrap();
+            let mut state = registry.lock().await;
+            state.jobs.get_mut(&id).unwrap().start().unwrap();
+        }
+
+        let resp2 = app.oneshot(make_req()).await.unwrap();
+        let (status2, body2) = read_json(resp2).await;
+        assert_eq!(status2, StatusCode::OK);
+        assert_eq!(body2["deduplicated"], serde_json::json!(true));
+        assert_eq!(body2["status"], "running");
+        assert_eq!(body2["job_id"], serde_json::json!(job_id));
+    }
+
+    /// `POST /api/jobs` with a missing required field returns 400 + the
+    /// `{"error":{"code","message"}}` envelope. Verifies the strict body
+    /// shape on the `missing_file` case so any envelope drift is caught.
+    #[tokio::test]
+    async fn post_missing_field_returns_400_envelope() {
+        let cases: &[(&str, Vec<u8>, &str, &str)] = &[
+            (
+                "missing file",
+                multipart_only_profile("BNDRY", "p"),
+                "missing_file",
+                "file field is missing",
+            ),
+            (
+                "missing profile",
+                multipart_only_file("BNDRY", b"hello"),
+                "missing_profile",
+                "profile field is missing",
+            ),
+        ];
+        for (label, body, want_code, want_message) in cases {
+            let (app, _registry, _storage, _queue_rx) = router();
+            let req = Request::builder()
+                .method("POST")
+                .uri("/api/jobs")
+                .header(
+                    "Content-Type",
+                    "multipart/form-data; boundary=BNDRY".to_string(),
+                )
+                .body(axum::body::Body::from(body.clone()))
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            let (status, json) = read_json(resp).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "case={label}");
+            assert_eq!(
+                json,
+                serde_json::json!({
+                    "error": { "code": *want_code, "message": *want_message }
+                }),
+                "case={label}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn get_unknown_job_returns_envelope() {
+        let (app, _registry, _storage, _queue_rx) = router();
+        let id = uuid::Uuid::new_v4();
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/api/jobs/{id}"))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["error"]["code"], "unknown_job_id");
+        assert!(body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains(&id.to_string()));
+    }
+
+    #[tokio::test]
+    async fn get_job_artifact_shape_object_when_succeeded() {
+        let (app, registry, _storage, _queue_rx) = router();
+        let job_id = {
+            let mut state = registry.lock().await;
+            let key = DedupKey::new("h".into(), "p".into());
+            let (id, _, _) = state.get_or_create(key, "p".into());
+            let job = state.jobs.get_mut(&id).unwrap();
+            job.start().unwrap();
+            job.succeed(std::path::PathBuf::from("/tmp/out.mp4"))
+                .unwrap();
+            id
+        };
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/api/jobs/{job_id}"))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], "succeeded");
+        assert!(body["artifact"].is_object());
+        assert_eq!(body["artifact"]["path"], "/tmp/out.mp4");
+    }
+
+    #[tokio::test]
+    async fn get_job_artifact_null_when_not_succeeded() {
+        let (app, registry, _storage, _queue_rx) = router();
+        let job_id = {
+            let mut state = registry.lock().await;
+            let key = DedupKey::new("h2".into(), "p".into());
+            let (id, _, _) = state.get_or_create(key, "p".into());
+            id
+        };
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/api/jobs/{job_id}"))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["artifact"], serde_json::Value::Null);
+    }
+
+    /// Covers every error envelope branch of `GET /api/jobs/:id/artifact`:
+    /// queued and running both map to `artifact_not_ready`, failed maps to
+    /// `job_failed`, and an unknown job id maps to `unknown_job_id`.
+    #[tokio::test]
+    async fn get_artifact_envelope_branches() {
+        let (app, registry, _storage, _queue_rx) = router();
+
+        let mk_get = |id: &str| {
+            Request::builder()
+                .method("GET")
+                .uri(format!("/api/jobs/{id}/artifact"))
+                .body(axum::body::Body::empty())
+                .unwrap()
+        };
+
+        let (queued_id, running_id, failed_id) = {
+            let mut state = registry.lock().await;
+            let qid = state
+                .get_or_create(DedupKey::new("hq".into(), "p".into()), "p".into())
+                .0;
+            let rid = state
+                .get_or_create(DedupKey::new("hr".into(), "p".into()), "p".into())
+                .0;
+            state.jobs.get_mut(&rid).unwrap().start().unwrap();
+            let fid = state
+                .get_or_create(DedupKey::new("hf".into(), "p".into()), "p".into())
+                .0;
+            let fjob = state.jobs.get_mut(&fid).unwrap();
+            fjob.start().unwrap();
+            fjob.fail("ffmpeg crashed".into()).unwrap();
+            (qid, rid, fid)
+        };
+        let unknown_id = uuid::Uuid::new_v4();
+
+        let cases = [
+            (
+                queued_id.to_string(),
+                StatusCode::CONFLICT,
+                "artifact_not_ready",
+            ),
+            (
+                running_id.to_string(),
+                StatusCode::CONFLICT,
+                "artifact_not_ready",
+            ),
+            (failed_id.to_string(), StatusCode::CONFLICT, "job_failed"),
+            (
+                unknown_id.to_string(),
+                StatusCode::NOT_FOUND,
+                "unknown_job_id",
+            ),
+        ];
+
+        for (id, want_status, want_code) in cases {
+            let resp = app.clone().oneshot(mk_get(&id)).await.unwrap();
+            let (status, body) = read_json(resp).await;
+            assert_eq!(status, want_status, "id={id}");
+            assert_eq!(body["error"]["code"], want_code, "id={id}");
+        }
     }
 }

--- a/src/dedup.rs
+++ b/src/dedup.rs
@@ -1,4 +1,4 @@
-use crate::shared::{DedupKey, Job};
+use crate::shared::{DedupKey, Job, JobStatus};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -23,23 +23,27 @@ impl RegistryState {
     }
 
     /// Atomic get-or-create operation under lock.
-    /// Returns (job_id, was_deduplicated).
-    pub fn get_or_create(&mut self, key: DedupKey, profile: String) -> (Uuid, bool) {
-        let job_id = Uuid::new_v4();
-
-        // Check if we have an existing job with same content_hash
-        let existing_job_id = self.dedup.get(&key).map(|e| e.job_id);
-
-        if let Some(existing_id) = existing_job_id {
-            return (existing_id, true);
+    /// Returns `(job_id, was_deduplicated, current_status)`. On a dedup hit
+    /// the status is the existing job's snapshot at this moment (not always
+    /// `Queued`). On a miss it is `JobStatus::Queued` (the freshly inserted
+    /// job).
+    pub fn get_or_create(&mut self, key: DedupKey, profile: String) -> (Uuid, bool, JobStatus) {
+        if let Some(entry) = self.dedup.get(&key) {
+            let existing_id = entry.job_id;
+            let status = self
+                .jobs
+                .get(&existing_id)
+                .map(|j| j.status)
+                .unwrap_or(JobStatus::Queued);
+            return (existing_id, true, status);
         }
 
-        // Create new job entry
-        let job = Job::new(job_id, profile.clone(), key.content_hash.clone());
+        let job_id = Uuid::new_v4();
+        let job = Job::new(job_id, profile, key.content_hash.clone());
         self.jobs.insert(job_id, job);
         self.dedup.insert(key, DedupEntry { job_id });
 
-        (job_id, false)
+        (job_id, false, JobStatus::Queued)
     }
 
     /// Roll back a freshly created (key, job_id) when staging or enqueue fails
@@ -66,4 +70,49 @@ pub type RegistryArc = Arc<Mutex<RegistryState>>;
 
 pub fn create_registry() -> RegistryArc {
     Arc::new(Mutex::new(RegistryState::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// On a dedup hit, the returned status must reflect the canonical job's
+    /// *current* state (not always `Queued`). Cover all four reachable
+    /// states with a single test.
+    #[tokio::test]
+    #[allow(clippy::type_complexity)]
+    async fn dedup_hit_returns_current_status_for_each_state() {
+        let cases: &[(fn(&mut Job), JobStatus)] = &[
+            (|_| {}, JobStatus::Queued),
+            (|j| j.start().unwrap(), JobStatus::Running),
+            (
+                |j| {
+                    j.start().unwrap();
+                    j.succeed(std::path::PathBuf::from("/tmp/out.mp4")).unwrap();
+                },
+                JobStatus::Succeeded,
+            ),
+            (
+                |j| {
+                    j.start().unwrap();
+                    j.fail("ffmpeg crashed".to_string()).unwrap();
+                },
+                JobStatus::Failed,
+            ),
+        ];
+        for (transition, want) in cases {
+            let mut state = RegistryState::new();
+            let key = DedupKey::new("h".to_string(), "p".to_string());
+            let (job_id, fresh, fresh_status) = state.get_or_create(key.clone(), "p".to_string());
+            assert!(!fresh);
+            assert_eq!(fresh_status, JobStatus::Queued);
+
+            transition(state.jobs.get_mut(&job_id).unwrap());
+
+            let (id2, dedup, status) = state.get_or_create(key, "p".to_string());
+            assert_eq!(id2, job_id, "want={want:?}");
+            assert!(dedup, "want={want:?}");
+            assert_eq!(status, *want);
+        }
+    }
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,3 +1,6 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use thiserror::Error;
@@ -121,6 +124,81 @@ mod tests {
         assert!(job.finished_at.is_some());
         assert_eq!(job.error, Some(error_msg.to_string()));
     }
+
+    async fn response_envelope(err: AppError) -> (StatusCode, serde_json::Value) {
+        let resp = err.into_response();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let body: serde_json::Value = serde_json::from_slice(&bytes).expect("body is JSON");
+        (status, body)
+    }
+
+    /// Externally-visible variants must serialize to the spec envelope with
+    /// the matching status code and a stable public message.
+    #[tokio::test]
+    #[allow(clippy::type_complexity)]
+    async fn envelope_external_variants() {
+        // (variant, status, code, message). AppError is not Clone, so the
+        // variant is built per iteration rather than stored.
+        let cases: &[(fn() -> AppError, StatusCode, &str, &str)] = &[
+            (
+                || AppError::MissingFile,
+                StatusCode::BAD_REQUEST,
+                "missing_file",
+                "file field is missing",
+            ),
+            (
+                || AppError::MissingProfile,
+                StatusCode::BAD_REQUEST,
+                "missing_profile",
+                "profile field is missing",
+            ),
+            (
+                || AppError::ArtifactNotReady,
+                StatusCode::CONFLICT,
+                "artifact_not_ready",
+                "artifact is not ready",
+            ),
+            (
+                || AppError::JobFailed,
+                StatusCode::CONFLICT,
+                "job_failed",
+                "job failed",
+            ),
+        ];
+        for (build, want_status, want_code, want_message) in cases {
+            let (status, body) = response_envelope(build()).await;
+            assert_eq!(status, *want_status, "code={want_code}");
+            assert_eq!(body["error"]["code"], *want_code);
+            assert_eq!(body["error"]["message"], *want_message);
+        }
+    }
+
+    /// JobNotFound carries a UUID, so its message is parametric — assert the
+    /// message contains the id rather than equality with a fixed string.
+    #[tokio::test]
+    async fn envelope_job_not_found_includes_id() {
+        let id = Uuid::new_v4();
+        let (status, body) = response_envelope(AppError::JobNotFound(id)).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["error"]["code"], "unknown_job_id");
+        assert!(body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains(&id.to_string()));
+    }
+
+    /// Internal-class variants must not leak their Display message.
+    #[tokio::test]
+    async fn envelope_internal_error_hides_details() {
+        let (status, body) =
+            response_envelope(AppError::FfmpegError("stderr leak: /private/path".into())).await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body["error"]["code"], "internal_error");
+        assert_eq!(body["error"]["message"], "internal server error");
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -200,8 +278,16 @@ impl Job {
 #[allow(dead_code)]
 #[derive(Debug, Error)]
 pub enum AppError {
-    #[error("Job not found: {0}")]
+    #[error("job not found: {0}")]
     JobNotFound(Uuid),
+    #[error("file field is missing")]
+    MissingFile,
+    #[error("profile field is missing")]
+    MissingProfile,
+    #[error("artifact is not ready")]
+    ArtifactNotReady,
+    #[error("job failed")]
+    JobFailed,
     #[error("Invalid status transition")]
     InvalidStatusTransition,
     #[error("FFmpeg error: {0}")]
@@ -212,6 +298,28 @@ pub enum AppError {
     YamlError(#[from] serde_yaml::Error),
     #[error("Storage error: {0}")]
     StorageError(String),
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let display = self.to_string();
+        let (status, code, message) = match &self {
+            AppError::JobNotFound(_) => (StatusCode::NOT_FOUND, "unknown_job_id", display),
+            AppError::MissingFile => (StatusCode::BAD_REQUEST, "missing_file", display),
+            AppError::MissingProfile => (StatusCode::BAD_REQUEST, "missing_profile", display),
+            AppError::ArtifactNotReady => (StatusCode::CONFLICT, "artifact_not_ready", display),
+            AppError::JobFailed => (StatusCode::CONFLICT, "job_failed", display),
+            _ => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                "internal server error".to_string(),
+            ),
+        };
+        let body = Json(serde_json::json!({
+            "error": { "code": code, "message": message }
+        }));
+        (status, body).into_response()
+    }
 }
 
 pub type AppResult<T> = std::result::Result<T, AppError>;

--- a/tests/dedup_registry_concurrent.rs
+++ b/tests/dedup_registry_concurrent.rs
@@ -31,11 +31,11 @@ async fn dedup_registry_concurrent_access() {
 
     let first_id = results[0].0;
     assert!(
-        results.iter().all(|(id, _)| *id == first_id),
+        results.iter().all(|(id, _, _)| *id == first_id),
         "all tasks must observe the same canonical job_id"
     );
     assert_eq!(
-        results.iter().filter(|(_, dedup)| !*dedup).count(),
+        results.iter().filter(|(_, dedup, _)| !*dedup).count(),
         1,
         "exactly one task must have created the canonical job"
     );


### PR DESCRIPTION
## Summary

Resolves #5. The server's response shape and status codes diverged from `docs/API_SPEC.md`, so the Python client failed to parse the artifact field and saw the wrong status code on POST. This change aligns the server with the spec and unblocks the client.

- Add `AppError` variants `MissingFile`, `MissingProfile`, `ArtifactNotReady`, `JobFailed` and an `IntoResponse` impl that serializes every error as `{"error":{"code","message"}}`. Internal-class variants map to a fixed message to avoid leaking implementation details.
- Make `RegistryState::get_or_create` synchronous and return `(Uuid, bool, JobStatus)` so dedup responses carry the existing job's current status. Callers no longer `.await` while holding the registry guard.
- `create_job` returns `201` for new jobs and `200` for dedup hits. `get_job` and `get_artifact` snapshot under the lock and release it before serializing or reading from disk. `get_artifact` returns 404/409/409 per spec.
- `get_job` serializes `artifact` as `{"path":"..."}` or `null` instead of a bare path string.
- Fix axum 0.7 path syntax (`:job_id`) so GET endpoints with a path parameter actually match.
- `client.py`: `format_timestamp` accepts `datetime` or `str`, unblocking the "Artifact:" display line.
- Enable tower 0.4 `util` feature for `ServiceExt` in tests.

## Acceptance criteria (from #5)

- [x] 새 job 생성 시 201, dedup hit 시 200
- [x] dedup 응답의 status 가 기존 job의 실제 상태
- [x] 모든 에러 응답이 `{"error":{"code","message"}}` envelope
- [x] GET /api/jobs/{id} 의 artifact 가 `{"path":...}` 객체 또는 null
- [x] python client/client.py status 가 artifact 필드 정상 표시
- [x] 단위/통합 테스트로 status code / envelope shape 회귀 방지

## Out of scope (deferred per design plan)

- `list_jobs` lock-during-serialize cleanup (architecture compliance, not #5 acceptance)
- Multipart extractor envelope bypass (#6 input validation)
- POST -> worker enqueue (#3 pipeline recovery)
- Artifact response headers / `output_extension` (#4, #9)
- `UnknownProfile` / `PayloadTooLarge` variants (#6)

## Test plan

- [x] `cargo test` — 25 passed (lib + bin)
  - 6 envelope unit tests in `src/shared.rs` (one per emitted variant + wildcard internal-error message regression)
  - 5 dedup tests in `src/dedup.rs` (concurrent access + 4-state status snapshot)
  - 14 HTTP-level integration tests in `src/api.rs` (POST 201, POST dedup 200 with current status, GET unknown 404, GET artifact-shape object/null, GET artifact endpoint queued/running/failed/unknown, POST missing_file/missing_profile envelopes)
- [x] `rustfmt --edition 2021 --check` — clean on changed files
- [x] Manual smoke against running server: 201 new / 200 dedup / 404 envelope / 409 envelope / RFC3339 timestamps / artifact dict shape
- [x] Python client `client.py status <id>` reaches print_job_status without TypeError; synthesized succeeded-job response prints `Artifact: data/jobs/.../proxy.mp4`

Note: `cargo clippy --all-targets -- -D warnings` reports 5 errors all in pre-existing baseline files (`worker.rs`, `queue.rs`, `dedup.rs::new` Default-impl, `shared.rs::JobStatus` derive-vs-impl). Changed files in this PR introduce no new clippy warnings. CI gate enforcement is tracked in #11.