### PR TITLE
fix(ci): clean up lint residue on qcn baseline

### DIFF
--- a/src/dedup.rs
+++ b/src/dedup.rs
@@ -24,11 +24,7 @@ impl RegistryState {
 
     /// Atomic get-or-create operation under lock.
     /// Returns (job_id, was_deduplicated).
-    pub fn get_or_create(
-        &mut self,
-        key: DedupKey,
-        profile: String,
-    ) -> (Uuid, bool) {
+    pub fn get_or_create(&mut self, key: DedupKey, profile: String) -> (Uuid, bool) {
         let job_id = Uuid::new_v4();
 
         // Check if we have an existing job with same content_hash

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -28,6 +28,7 @@ impl JobStatus {
         }
     }
 
+    #[allow(dead_code)]
     pub fn is_terminal(&self) -> bool {
         matches!(self, JobStatus::Succeeded | JobStatus::Failed)
     }
@@ -196,6 +197,7 @@ impl Job {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Error)]
 pub enum AppError {
     #[error("Job not found: {0}")]


### PR DESCRIPTION
## Why

PR #19 introduced a CI gate (`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all`) but landed on `qcn` while baseline lint residue still existed, so subsequent PRs (e.g. #18) hit CI failures even when they don't conflict with the base.

## What

- `src/dedup.rs`: apply `rustfmt` to `RegistryState::get_or_create` signature.
- `src/shared.rs`: add `#[allow(dead_code)]` to items intentionally retained for upcoming issues:
  - `JobStatus::is_terminal`
  - `pub enum AppError` (variants `JobNotFound`, `InvalidStatusTransition`, `FfmpegError`, `StorageError`)

No behavioral change. Items are not removed because follow-up issues will use them.

## Scope

Deliberately does **not** touch the file scope of in-flight PR #18 (`feat/issue-9-output-extension`): `src/api.rs`, `src/ffmpeg.rs`, `src/main.rs`, `src/worker.rs`, `Cargo.toml`, `README.md`, `docs/API_SPEC.md`, `profiles.yaml`. Any remaining `cargo fmt --check` diffs in those files will be resolved by #18's own edits when it lands; addressing them here would create avoidable conflicts.

## Verification

Run on this branch:

- `cargo clippy --all-targets -- -D warnings` -> 0 errors
- `cargo test --all` -> all tests pass (placeholders ignored as before)
- `cargo fmt --check` -> clean for files in this PR's scope (`src/dedup.rs`, `src/shared.rs`); residual diffs remain only in #18's file scope and will clear on #18 merge.