### PR TITLE
Issue #11: enforce no unwrap/expect in production + clean lib.rs.bak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,8 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      - name: No unwrap/expect in production
+        run: cargo clippy --lib --bins --no-deps -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
+
       - name: Tests
         run: cargo test --all

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .venv
 .qwen
 Cargo.lock
+*.bak

--- a/src/lib.rs.bak
+++ b/src/lib.rs.bak
@@ -1,8 +1,0 @@
-pub mod api;
-pub mod config;
-pub mod dedup;
-pub mod ffmpeg;
-pub mod queue;
-pub mod shared;
-pub mod storage;
-pub mod worker;


### PR DESCRIPTION
## Summary
- **Issue #11 step 4 (cleanup)**: removes the tracked `src/lib.rs.bak` and adds `*.bak` to `.gitignore` so future backup files stay out of git.
- **Production unwrap/expect lint enforcement (developer-added on top of Issue #11)**: adds a CI step `No unwrap/expect in production` between the existing `Clippy` and `Tests` steps. The step runs `cargo clippy --lib --bins --no-deps -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`, which automates the rule from `README.md:193` and `docs/TEST_PLAN.md:126` ("Implementation code should not use `unwrap()` or `expect()` outside tests").
- No production or test code changes. Baseline already at zero violations on `qcn`. `--lib --bins` skips integration tests and inline `#[cfg(test)]` modules so no test files need `#![allow(...)]`. `--no-deps` ignores dependency lints.

Issue #11's other completion criteria (`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, no production unwrap, `.github/workflows/ci.yml` exists) are already satisfied on `qcn`; this PR closes the remaining gap.

## Test plan
- [x] `cargo fmt --check` — green
- [x] `cargo clippy --all-targets -- -D warnings` — green
- [x] `cargo clippy --lib --bins --no-deps -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` — green
- [x] `cargo test --all` — all unit + integration tests green (mock-based, no ffmpeg system binary required locally)
- [x] `git ls-files src/lib.rs.bak` empty; `.gitignore` contains `*.bak`
- [x] No `#[allow(clippy::unwrap_used|expect_used)]` introduced (`rg` 0 hits)
- [x] No `examples/`, `benches/`, `build.rs`, or proc-macro targets exist (`--lib --bins` covers all current production targets)
- [ ] GitHub Actions: `Format check` / `Clippy` / `No unwrap/expect in production` / `Tests` all green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)