### PR TITLE
feat: validate POST /api/jobs requests (Issue #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ The `output_extension` field is optional and defaults to `mp4`. It must match `^
 
 See [API specification](docs/API_SPEC.md#profile-configuration) for the full schema and the extension-to-MIME mapping used by `GET /api/jobs/{job_id}/artifact`.
 
+## Upload Size Limit
+
+`POST /api/jobs` rejects requests whose encoded multipart body exceeds `--max-upload-bytes` (default 50 MiB) with a `413 payload_too_large` envelope. The limit applies to the entire encoded body, including boundary delimiters and part headers, not just the file contents.
+
+`--max-upload-bytes` is a per-request cap; it does not bound the number of concurrent uploads. With the current buffered upload path each in-flight request can hold up to the limit in memory, so concurrent traffic should be sized accordingly. True streaming with bounded memory is tracked by the streaming follow-up issue.
+
 ## Out of Scope
 
 - database persistence, including SQLite and PostgreSQL

--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -120,7 +120,10 @@ Errors:
 | 400 | `missing_file` | multipart request has no `file` field |
 | 400 | `missing_profile` | multipart request has no `profile` field |
 | 400 | `unknown_profile` | profile name is not configured |
-| 413 | `payload_too_large` | uploaded body exceeds the configured maximum size |
+| 400 | `invalid_multipart` | multipart wire-protocol parse failure: missing or invalid `boundary`, non-multipart `Content-Type`, truncated body, multipart header parse error, or invalid UTF-8 in the `profile` field |
+| 413 | `payload_too_large` | encoded multipart body exceeds the configured maximum size |
+
+The `payload_too_large` limit is applied to the entire encoded multipart body — boundary delimiters, part headers, and file bytes summed — not to the raw file contents alone. The limit is configured per-request via the `--max-upload-bytes` CLI flag and is not a concurrency cap.
 
 If the client disconnects before upload completion, the server may not be able to send a response. The server-side behavior is still defined: no content hash is finalized, no job metadata is inserted, and no job is enqueued.
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,8 +5,8 @@ use crate::shared::{AppError, DedupKey, Job, JobStatus};
 use crate::storage::Storage;
 use axum::{
     body::{Body, Bytes},
-    extract::multipart::Multipart,
-    extract::{Path, State},
+    extract::multipart::{Multipart, MultipartError, MultipartRejection},
+    extract::{DefaultBodyLimit, Path, State},
     http::{header, StatusCode},
     response::{Json, Response},
     routing::{get, post},
@@ -16,6 +16,18 @@ use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use tokio::fs;
 use tokio_util::io::ReaderStream;
+
+/// Map a `MultipartError` raised during field iteration to the corresponding
+/// `AppError`. `DefaultBodyLimit` overages surface here (status 413), while
+/// any other parse failure (truncated body, header errors, etc.) is treated
+/// as a wire-protocol violation.
+fn map_multipart_err(err: MultipartError) -> AppError {
+    if err.status() == StatusCode::PAYLOAD_TOO_LARGE {
+        AppError::PayloadTooLarge
+    } else {
+        AppError::InvalidMultipart
+    }
+}
 
 #[derive(Clone)]
 pub struct AppState {
@@ -49,20 +61,20 @@ pub async fn health() -> Json<serde_json::Value> {
 
 pub async fn create_job(
     State(state): State<AppState>,
-    mut multipart: Multipart,
+    multipart: Result<Multipart, MultipartRejection>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), AppError> {
+    // Extractor-level rejection (missing/invalid boundary, non-multipart
+    // `Content-Type`, etc.) maps to `invalid_multipart`. axum 0.7 surfaces
+    // `DefaultBodyLimit` overages later, via `MultipartError::status() == 413`
+    // inside the field iteration loop, not here.
+    let mut multipart = multipart.map_err(|_| AppError::InvalidMultipart)?;
+
     let mut file_data: Option<(String, String)> = None;
     let mut profile_str: Option<String> = None;
 
-    // Multipart parse failures map best-effort to MissingFile/MissingProfile;
-    // #6 (input validation) will tighten the wire-protocol error mapping.
-    while let Some(field) = multipart
-        .next_field()
-        .await
-        .map_err(|_| AppError::MissingFile)?
-    {
+    while let Some(field) = multipart.next_field().await.map_err(map_multipart_err)? {
         let name = field.name().unwrap_or("").to_string();
-        let bytes: Bytes = field.bytes().await.map_err(|_| AppError::MissingFile)?;
+        let bytes: Bytes = field.bytes().await.map_err(map_multipart_err)?;
 
         if name == "file" {
             let mut hasher = Sha256::new();
@@ -75,13 +87,43 @@ pub async fn create_job(
 
             file_data = Some((hash, filename));
         } else if name == "profile" {
-            profile_str =
-                Some(String::from_utf8(bytes.to_vec()).map_err(|_| AppError::MissingProfile)?);
+            // Wire/encoding-level violation -> invalid_multipart, distinct
+            // from the structural missing_profile case (= valid multipart
+            // with no `profile` field at all). Clean up any tmp the `file`
+            // branch already staged before returning, since this PR owns
+            // this new error path.
+            profile_str = Some(match String::from_utf8(bytes.to_vec()) {
+                Ok(s) => s,
+                Err(_) => {
+                    if let Some((_, prev_filename)) = &file_data {
+                        let _ = state.storage.cleanup_tmp(prev_filename);
+                    }
+                    return Err(AppError::InvalidMultipart);
+                }
+            });
         }
     }
 
     let (content_hash, filename) = file_data.ok_or(AppError::MissingFile)?;
-    let profile = profile_str.ok_or(AppError::MissingProfile)?;
+
+    // From here on the file has been staged to tmp, so the validation
+    // failures introduced by this PR (`missing_profile` after a file field,
+    // `unknown_profile`) clean it up explicitly before returning.
+    let profile = match profile_str {
+        Some(p) => p,
+        None => {
+            let _ = state.storage.cleanup_tmp(&filename);
+            return Err(AppError::MissingProfile);
+        }
+    };
+
+    // Synchronous, lock-free profile validation. `Transcoder::get_profile`
+    // is sync, so this satisfies the "no `.await` while holding the registry
+    // lock" rule trivially — we validate before taking the registry lock.
+    if state.transcoder.get_profile(&profile).is_none() {
+        let _ = state.storage.cleanup_tmp(&filename);
+        return Err(AppError::UnknownProfile(profile));
+    }
 
     let key = DedupKey::new(content_hash.clone(), profile.clone());
     let profile_for_response = profile.clone();
@@ -255,6 +297,7 @@ pub fn create_router(
     storage: Arc<Storage>,
     queue_tx: JobSender,
     transcoder: Arc<dyn Transcoder>,
+    max_upload_bytes: usize,
 ) -> Router {
     let state = AppState {
         registry,
@@ -264,9 +307,16 @@ pub fn create_router(
     };
 
     // axum 0.7 + matchit 0.7 use ":name" path-param syntax; "{name}" is matchit 0.8 / axum 0.8.
+    // The body-limit layer is attached only to POST /api/jobs because the
+    // GET endpoints carry no request body. axum 0.7 surfaces an overage as
+    // `MultipartError::status() == 413`, which `map_multipart_err` maps to
+    // `AppError::PayloadTooLarge`.
     Router::new()
         .route("/api/health", get(health))
-        .route("/api/jobs", post(create_job))
+        .route(
+            "/api/jobs",
+            post(create_job).layer(DefaultBodyLimit::max(max_upload_bytes)),
+        )
         .route("/api/jobs", get(list_jobs))
         .route("/api/jobs/:job_id", get(get_job))
         .route("/api/jobs/:job_id/artifact", get(get_artifact))
@@ -294,7 +344,16 @@ mod tests {
         }]))
     }
 
+    /// Default test router with a generous body limit (1 MiB) so existing
+    /// happy-path / dedup / artifact tests are unaffected by the upload cap.
+    /// Body-limit-specific tests build their own router via `router_with_limit`.
     fn router() -> (Router, RegistryArc, Arc<Storage>, JobReceiver) {
+        router_with_limit(1024 * 1024)
+    }
+
+    fn router_with_limit(
+        max_upload_bytes: usize,
+    ) -> (Router, RegistryArc, Arc<Storage>, JobReceiver) {
         let registry = create_registry();
         let tmp = std::env::temp_dir().join(format!("syspref_test_{}", uuid::Uuid::new_v4()));
         let storage = Arc::new(Storage::new(&tmp));
@@ -305,6 +364,7 @@ mod tests {
             storage.clone(),
             queue_tx,
             test_transcoder(),
+            max_upload_bytes,
         );
         // Return queue_rx so it stays alive in the test scope; otherwise
         // queue_tx.send() in create_job's staging fails with channel closed.
@@ -716,5 +776,160 @@ mod tests {
             assert_eq!(status, want_status, "id={id}");
             assert_eq!(body["error"]["code"], want_code, "id={id}");
         }
+    }
+
+    // ---------- HTTP-level acceptance for issue #6 (request validation) ----------
+
+    /// E3: unregistered profile name is rejected before staging/enqueue with
+    /// the documented 400 + `unknown_profile` envelope. Side-assertion: the
+    /// tmp directory is empty afterwards (cleanup wrapper) and no job /
+    /// dedup entry was created in the registry, no enqueue happened.
+    #[tokio::test]
+    async fn post_unknown_profile_returns_400_envelope_and_cleans_up() {
+        let (app, registry, storage, queue_rx) = router();
+        let boundary = "BNDRY";
+        let body = multipart_body(boundary, b"hello world", "does_not_exist");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/jobs")
+            .header(
+                "Content-Type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(axum::body::Body::from(body))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let (status, json) = read_json(resp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(json["error"]["code"], "unknown_profile");
+        // Display intentionally hides the offending profile name.
+        assert_eq!(json["error"]["message"], "profile does not exist");
+        assert!(!json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("does_not_exist"));
+
+        // Side assertions: registry and queue are untouched.
+        let registry_state = registry.lock().await;
+        assert!(registry_state.dedup.is_empty(), "dedup map must be empty");
+        assert!(registry_state.jobs.is_empty(), "jobs map must be empty");
+        drop(registry_state);
+        assert!(
+            queue_rx.lock().await.try_recv().is_err(),
+            "queue must be empty"
+        );
+
+        // Side assertion: no leftover tmp file. `tmp_path("")` returns the
+        // tmp directory itself (base_path/tmp), which Storage::ensure_exists
+        // creates upfront, so it should exist but be empty after cleanup.
+        let tmp_dir = storage.tmp_path("");
+        let entries: Vec<_> = std::fs::read_dir(&tmp_dir)
+            .unwrap_or_else(|e| panic!("read tmp dir {tmp_dir:?}: {e}"))
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "tmp dir must be empty, found: {entries:?}"
+        );
+    }
+
+    /// E4 + L1: the configured body limit produces a 413 + `payload_too_large`
+    /// JSON envelope (not the default plain-text rejection). Proves that
+    /// `DefaultBodyLimit` overage flows through `MultipartError::status()`
+    /// into the handler so envelope mapping kicks in.
+    #[tokio::test]
+    async fn post_oversized_body_returns_413_envelope() {
+        // Tight cap so a small but normal-looking multipart body trips it.
+        let (app, _registry, _storage, _queue_rx) = router_with_limit(256);
+        let boundary = "BNDRY";
+        // ~1 KiB file payload guarantees the encoded body exceeds 256 bytes.
+        let payload = vec![b'A'; 1024];
+        let body = multipart_body(boundary, &payload, "p");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/jobs")
+            .header(
+                "Content-Type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(axum::body::Body::from(body))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let (status, json) = read_json(resp).await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(json["error"]["code"], "payload_too_large");
+        assert_eq!(json["error"]["message"], "request body exceeds limit");
+    }
+
+    /// C5 / C10: malformed multipart at the wire-protocol layer maps to
+    /// 400 + `invalid_multipart`. Covers the extractor-level rejection
+    /// (non-multipart Content-Type).
+    #[tokio::test]
+    async fn post_non_multipart_content_type_returns_invalid_multipart() {
+        let (app, _registry, _storage, _queue_rx) = router();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/jobs")
+            .header("Content-Type", "application/json")
+            .body(axum::body::Body::from(r#"{"profile":"p"}"#))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let (status, json) = read_json(resp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(json["error"]["code"], "invalid_multipart");
+        assert_eq!(json["error"]["message"], "invalid multipart request");
+    }
+
+    /// C5: invalid UTF-8 bytes in the `profile` field surface as
+    /// `invalid_multipart`, not `missing_profile` — the multipart envelope is
+    /// well-formed but the field's payload violates the textual contract.
+    /// Side-assertion: when the invalid `profile` arrives AFTER a valid
+    /// `file` part, the staged tmp must be cleaned up (this PR introduced
+    /// the InvalidMultipart mapping and owns the cleanup).
+    #[tokio::test]
+    async fn post_invalid_utf8_profile_returns_invalid_multipart() {
+        let (app, _registry, storage, _queue_rx) = router();
+        let boundary = "BNDRY";
+        // Build a multipart body where the `profile` part contains a lone
+        // 0xFF byte (invalid UTF-8). `file` part is included first so the
+        // tmp-cleanup side-assertion has something to verify.
+        let mut body = Vec::new();
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"v.mp4\"\r\n\r\n",
+        );
+        body.extend_from_slice(b"hello");
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"profile\"\r\n\r\n");
+        body.extend_from_slice(&[0xFFu8]);
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/jobs")
+            .header(
+                "Content-Type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(axum::body::Body::from(body))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let (status, json) = read_json(resp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(json["error"]["code"], "invalid_multipart");
+
+        let tmp_dir = storage.tmp_path("");
+        let entries: Vec<_> = std::fs::read_dir(&tmp_dir)
+            .unwrap_or_else(|e| panic!("read tmp dir {tmp_dir:?}: {e}"))
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "tmp dir must be empty after invalid-utf8 profile, found: {entries:?}"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
 
+pub const DEFAULT_MAX_UPLOAD_BYTES: usize = 50 * 1024 * 1024;
+
 #[derive(Parser, Debug)]
 #[command(name = "syspref-ingest")]
 #[command(about = "Video Digest Server - concurrent video upload and transcoding")]
@@ -17,6 +19,12 @@ pub struct Config {
     /// HTTP server address
     #[arg(short, long, default_value = "127.0.0.1:8080")]
     pub bind: String,
+
+    /// Per-request multipart body size limit in bytes. Applies to the entire
+    /// encoded multipart body (boundary delimiters + part headers + file
+    /// data). This is a per-request cap, not a concurrency limiter.
+    #[arg(long, default_value_t = DEFAULT_MAX_UPLOAD_BYTES)]
+    pub max_upload_bytes: usize,
 }
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,8 +95,14 @@ async fn main() -> Result<()> {
     worker_pool.start().await;
 
     // Create router (producer side holds the sender + profile lookup via trait)
-    let app = api::create_router(registry, storage.clone(), queue_tx, transcoder)
-        .layer(TraceLayer::new_for_http());
+    let app = api::create_router(
+        registry,
+        storage.clone(),
+        queue_tx,
+        transcoder,
+        config.max_upload_bytes,
+    )
+    .layer(TraceLayer::new_for_http());
 
     // Start server
     let addr = config.bind.parse::<std::net::SocketAddr>()?;

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -284,6 +284,16 @@ pub enum AppError {
     MissingFile,
     #[error("profile field is missing")]
     MissingProfile,
+    // The carried profile name is intentionally NOT interpolated into Display
+    // so the IntoResponse path (which uses Display as the client message)
+    // cannot leak the rejected profile name. The String is kept for server-
+    // side Debug logging only.
+    #[error("profile does not exist")]
+    UnknownProfile(String),
+    #[error("invalid multipart request")]
+    InvalidMultipart,
+    #[error("request body exceeds limit")]
+    PayloadTooLarge,
     #[error("artifact is not ready")]
     ArtifactNotReady,
     #[error("job failed")]
@@ -307,6 +317,11 @@ impl IntoResponse for AppError {
             AppError::JobNotFound(_) => (StatusCode::NOT_FOUND, "unknown_job_id", display),
             AppError::MissingFile => (StatusCode::BAD_REQUEST, "missing_file", display),
             AppError::MissingProfile => (StatusCode::BAD_REQUEST, "missing_profile", display),
+            AppError::UnknownProfile(_) => (StatusCode::BAD_REQUEST, "unknown_profile", display),
+            AppError::InvalidMultipart => (StatusCode::BAD_REQUEST, "invalid_multipart", display),
+            AppError::PayloadTooLarge => {
+                (StatusCode::PAYLOAD_TOO_LARGE, "payload_too_large", display)
+            }
             AppError::ArtifactNotReady => (StatusCode::CONFLICT, "artifact_not_ready", display),
             AppError::JobFailed => (StatusCode::CONFLICT, "job_failed", display),
             _ => (


### PR DESCRIPTION
## Summary

Resolves #6.

`POST /api/jobs` accepted any profile name and had no body size limit, so unknown profiles failed only at the worker stage and oversize uploads were unbounded. This change makes request-time validation match the four error envelopes documented in `docs/API_SPEC.md` and adds a per-request body cap.

- Add `AppError` variants `UnknownProfile(String)`, `InvalidMultipart`, and `PayloadTooLarge` with `IntoResponse` arms (400 `unknown_profile` / 400 `invalid_multipart` / 413 `payload_too_large`). `UnknownProfile` carries the offending name for server-side Debug logging only; the client message is the fixed `"profile does not exist"` so the rejected name cannot leak.
- `create_job` validates the profile via `state.transcoder.get_profile()` outside the registry lock. Multipart parse failures (extractor-level rejection or in-loop `MultipartError`) map to `invalid_multipart`; `DefaultBodyLimit` overage (`MultipartError::status() == 413`) maps to `payload_too_large`. New `MissingProfile`-after-file, `UnknownProfile`, and `InvalidMultipart`-after-file paths each clean up the staged tmp inline before returning. Dedup-hit and dedup-miss-staging paths are unchanged from `qcn`.
- Add `Config::max_upload_bytes` (`--max-upload-bytes`, default 50 MiB) and attach `axum::extract::DefaultBodyLimit::max(N)` to `POST /api/jobs`. `GET` endpoints are unaffected.
- `docs/API_SPEC.md` adds a 400 `invalid_multipart` row and clarifies that the `payload_too_large` limit applies to the entire encoded multipart body (boundary delimiters + part headers + file bytes).
- `README` adds an Upload Size Limit section noting the cap is per-request and not a concurrency limiter; bounded-memory streaming remains tracked by the streaming follow-up issue.

## Acceptance criteria (from #6)

- [x] Unknown profile → 400 envelope `{"error":{"code":"unknown_profile","message":"profile does not exist"}}`
- [x] Missing `file` → 400 `missing_file`
- [x] Missing `profile` → 400 `missing_profile`
- [x] Body exceeds limit → 413 `payload_too_large`
- [x] `Config` has `max_upload_bytes` option (CLI flag)
- [x] Four-case unit/integration tests

## Out of scope (intentional)

- Streaming uploads + incremental SHA-256 (separate issue, follow-up).
- Existing `qcn` baseline behaviors retained without expansion: in-loop multipart errors after a `file` part is staged still leak the tmp; duplicate `file` parts use last-wins (the superseded tmp is left in place); a partial `data/jobs/{job_id}/` directory may remain after a staging failure. These are acknowledged limitations to keep this PR focused on Issue #6's documented error contract.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all` — 35 passed, 0 failed, 4 intentional placeholders ignored
  - 4 new HTTP-level oneshot tests for issue #6:
    - `post_unknown_profile_returns_400_envelope_and_cleans_up` (asserts registry/queue/tmp untouched)
    - `post_oversized_body_returns_413_envelope` (256-byte cap)
    - `post_non_multipart_content_type_returns_invalid_multipart`
    - `post_invalid_utf8_profile_returns_invalid_multipart` (asserts tmp cleaned when invalid profile follows valid file part)
- [ ] Manual: `curl` scenarios from the issue body against a local server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)